### PR TITLE
Check for socket.timeout exceptions when executing a request.

### DIFF
--- a/pygsheets/client.py
+++ b/pygsheets/client.py
@@ -22,6 +22,7 @@ from .custom_types import *
 from .utils import format_addr
 
 import httplib2
+import socket
 from json import load as jload
 from googleapiclient import discovery
 from googleapiclient import http as ghttp
@@ -437,11 +438,9 @@ class Client(object):
             for i in range(self.retries):
                 try:
                     response = request.execute()
-                except Exception as e:
-                    if str(e).find('timed out') == -1:
-                        raise
+                except socket.timeout:
                     if i == self.retries-1:
-                        raise RequestError("Timeout")
+                        raise
                     # print ("Cant connect, retrying ... " + str(i))
                 else:
                     return response


### PR DESCRIPTION
This should solve #106.

httplib2 raises a socket.timeout exception when a request times out.  This commit just excepts socket.timeout to allow for retries, and any other exceptions are raised immediately.  Instead of creating a new RequestError, I just raise the socket.timeout (which contains the text "timed out" that you were originally searching for).