### PR TITLE
Ignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pygsheets.egg-info/
 service_creds.json
 .DS_Store
 .coverage
+venv/


### PR DESCRIPTION
Ref http://sourabhbajaj.com/mac-setup/Python/virtualenv.html

Adding to project ignore ensures it won't get added by mistake.
People may or may not have their global ignores set up correctly.