### PR TITLE
Ignore creds files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ test/usages
 test/data/*.json
 test/manual_test1.py
 creds.json
+client_secret.json
+sheets.googleapis.com-python.json
 .idea/
 .cache/
 pygsheets.egg-info/

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ sh = gc.open("pygsheetTest")
 # If you want to be specific, use a key
 sht1 = gc.open_by_key('1mwA-NmvjDqd3A65c8hsxOpqdfdggPR0fgfg5nXRKScZAuM')
 
-# Or,paste the entire url
-sht2 = gc.open_by_url('https://docs.google.com/spreadsheets/d/1mwA...AuM/edit')
+# create a spreasheet in a folder (by id)
+sht2 = gc.create("new sheet", parent_id="adF345vfvcvby67ddfc")
 
 # open enable TeamDrive support
 gc.enableTeamDriveSupport=True
@@ -166,6 +166,9 @@ for row in wks:
 
 # get values by indexes
  A1_value = wks[0][0]
+
+# clear all values
+wks.clear()
 
 # Search for a table in the worksheet and append a row to it
 wks.append_table(values=[1,2,3,4])

--- a/pygsheets/__init__.py
+++ b/pygsheets/__init__.py
@@ -8,7 +8,7 @@ Google Spreadsheets client library.
 
 """
 
-__version__ = 'v1.1.2'
+__version__ = '1.1.3'
 __author__ = 'Nithin Murali'
 
 

--- a/pygsheets/datarange.py
+++ b/pygsheets/datarange.py
@@ -30,8 +30,10 @@ class DataRange(object):
     def __init__(self, start=None, end=None, worksheet=None, name='', data=None, name_id=None, namedjson=None):
         self._worksheet = worksheet
         if namedjson:
-            start = (namedjson['range']['startRowIndex']+1, namedjson['range']['startColumnIndex']+1)
-            end = (namedjson['range']['endRowIndex'], namedjson['range']['endColumnIndex'])
+            start = (namedjson['range'].get('startRowIndex', 0)+1, namedjson['range'].get('startColumnIndex', 0)+1)
+            # @TODO this wont scale if the sheet size is changed
+            end = (namedjson['range'].get('endRowIndex', self._worksheet.cols),
+                   namedjson['range'].get('endColumnIndex', self._worksheet.rows))
             name_id = namedjson['namedRangeId']
         data = [[]]
         self._start_addr = format_addr(start, 'tuple')

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -229,7 +229,7 @@ class Worksheet(object):
 
         Example:
 
-        >>> wks.values((1,1),(3,3))
+        >>> wks.get_values((1,1),(3,3))
         [[u'another look.', u'', u'est'],
          [u'EE 4212', u"it's down there "],
          [u'ee 4210', u'somewhere, let me take ']]
@@ -342,8 +342,8 @@ class Worksheet(object):
 
         :param addr: cell address as tuple (row,column) or label 'A1'.
         :param val: New value
-        :param parse: if the values should be stored \
-                        as is or should be as if the user typed them into the UI
+        :param parse: if False, values will be stored \
+                        as else as if the user typed them into the UI
 
         Example:
 
@@ -688,7 +688,7 @@ class Worksheet(object):
                       x['range'].get('sheetId', 0) == self.id]
             return nrange
         else:
-            nrange = [x for x in self.spreadsheet.named_ranges if x['name'] == name and x['range']['sheetId']==self.id]
+            nrange = [x for x in self.spreadsheet.named_ranges if x['name'] == name and x['range'].get('sheetId', 0) == self.id]
             if len(nrange) == 0:
                 self.spreadsheet.update_properties()
                 nrange = [x for x in self.spreadsheet.named_ranges if


### PR DESCRIPTION
During the initial setup of this library, I downloaded the creds as-is from Google, and authorized the app.  I then have the following untracked files in my working directory:

    client_secret.json
    sheets.googleapis.com-python.json

It's good practice to ignore anything that shouldn't be committed.  The `.gitignore` already has some .json files ignored ... should this PR be changed to ignore just `*.json` ?