### PR TITLE
get_named_range

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ wks.title = "NewTitle"
 
 # working with named ranges
 wks.create_named_range('A1', 'A10', 'prices')
+wks.get_named_range('prices')
 wks.get_named_ranges()  # will return a list of DataRange objects
 wks.delete_named_range('prices')
 

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -736,13 +736,7 @@ class Worksheet(object):
             nrange = [x for x in self.spreadsheet.named_ranges if x.worksheet.id == self.id]
             return nrange
         else:
-            nrange = [x for x in self.spreadsheet.named_ranges if x.name == name and x.worksheet.id == self.id]
-            if len(nrange) == 0:
-                self.spreadsheet.update_properties()
-                nrange = [x for x in self.spreadsheet.named_ranges if x.name == name and x.worksheet.id == self.id]
-                if len(nrange) == 0:
-                    raise RangeNotFound(name)
-            return nrange[0]
+            return self.get_named_range(name)
 
     def delete_named_range(self, name, range_id=''):
         """delete a named range

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -707,6 +707,22 @@ class Worksheet(object):
         self.client.sh_batch_update(self.spreadsheet.id, request, batch=self.spreadsheet.batch_mode)
         return DataRange(start, end, self, name)
 
+    def get_named_range(self, name):
+        """
+        get a named range given name
+
+        :param name: Name of the named range to be retrived, if omitted all ranges are retrived
+        :return: :class:`DataRange`
+
+        """
+        nrange = [x for x in self.spreadsheet.named_ranges if x.name == name and x.worksheet.id == self.id]
+        if len(nrange) == 0:
+            self.spreadsheet.update_properties()
+            nrange = [x for x in self.spreadsheet.named_ranges if x.name == name and x.worksheet.id == self.id]
+            if len(nrange) == 0:
+                raise RangeNotFound(name)
+        return nrange[0]
+
     def get_named_ranges(self, name=''):
         """
         get a named range given name


### PR DESCRIPTION
Hi, Nithin

Have a look at this suggestion. In my opinion, it's a more natural way of getting a named range, than reusing `get_named_ranges()`.  

It took me quite a quite to understand that `get_named_ranges()` is able to fetch one one range as well. 

This pull-request is backwards-compatible so that the code that uses `get_named_ranges()` for this aim won't break.

Best regards,
  Lev