### PR TITLE
dimensions visibility control methods

### DIFF
--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -673,6 +673,87 @@ class Worksheet(object):
 
         self.client.sh_batch_update(self.spreadsheet.id, request, batch=self.spreadsheet.batch_mode)
 
+    def update_dimensions_visibility(self, start, end=None, dimension="ROWS", hidden=True):
+        """Set visibility of dimensions
+
+        :param start: index of the dimension visibility to be changed
+        :param end: index of the end dimension that visibility will be changed
+        :param dimension: ('ROW' or 'COLUMN') dimension that visibility will be changed
+        :param hidden: hide dimension"""
+
+        if end is None or end <= start:
+            end = start + 1
+
+        request = {
+                      "updateDimensionProperties": {
+                          "range": {
+                              "sheetId": self.id,
+                              "dimension": dimension,
+                              "startIndex": start,
+                              "endIndex": end
+                          },
+                          "properties": {
+                              "hiddenByUser": hidden
+                          },
+                          "fields": "hiddenByUser"
+                      }
+                  },
+
+        self.client.sh_batch_update(self.spreadsheet.id, request, batch=self.spreadsheet.batch_mode)
+
+    def hide_dimensions(self, start, end=None, dimension="ROWS"):
+        """Hide dimensions
+
+        :param start: index of the dimension to be hidden
+        :param end: index of the end dimension that will be hidden
+        :param dimension: ('ROW' or 'COLUMN') dimension which will be hidden
+        """
+        self.update_dimensions_visibility(start, end, dimension, hidden=True)
+
+    def show_dimensions(self, start, end=None, dimension="ROWS"):
+        """Show dimensions
+
+        :param start: index of the dimension to be shown
+        :param end: index of the end dimension that will be shown
+        :param dimension: ('ROW' or 'COLUMN') dimension which will be shown
+        """
+        self.update_dimensions_visibility(start, end, dimension, hidden=False)
+
+    def hide_rows(self, start, end=None):
+        """Hide rows
+
+        :param start: index of the row to be hidden
+        :param end: index of the end row that will be hidden
+        """
+        self.hide_dimensions(start, end, "ROWS")
+
+    def show_rows(self, start, end=None):
+        """Show rows
+
+        :param start: index of the row to be shown
+        :param end: index of the end row that will be shown
+        """
+
+        self.show_dimensions(start, end, "ROWS")
+
+    def hide_columns(self, start, end=None):
+        """Hide columns
+
+        :param start: index of the column to be hidden
+        :param end: index of the end column that will be hidden
+        """
+
+        self.hide_dimensions(start, end, "COLUMNS")
+
+    def show_columns(self, start, end=None):
+        """Show columns
+
+        :param start: index of the column to be shown
+        :param end: index of the end column that will be shown
+        """
+
+        self.show_dimensions(start, end, "COLUMNS")
+
     def adjust_row_height(self, start, end=None, pixel_size=100):
         """Adjust the height of one or more rows
 

--- a/test/online_test.py
+++ b/test/online_test.py
@@ -394,6 +394,26 @@ class TestWorkSheet(object):
                                                                           [Cell('A2','2'), Cell('B2','3'), Cell('C2','4')]]
         assert self.worksheet.get_values('D1', 'D3', returnas="cells", include_all=True) == [[Cell('D1', '')], [Cell('D2', '')], [Cell('D3', '')]]
 
+    def test_hide_rows(self):
+        self.worksheet.hide_rows(0, 2)
+        json =self.spreadsheet.client.sh_get_ssheet(self.spreadsheet.id, fields="sheets/data/rowMetadata/hiddenByUser")
+        assert json['sheets'][0]['data'][0]['rowMetadata'][0]['hiddenByUser'] == True
+        assert json['sheets'][0]['data'][0]['rowMetadata'][1]['hiddenByUser'] == True
+        self.worksheet.show_rows(0, 2)
+        json =self.spreadsheet.client.sh_get_ssheet(self.spreadsheet.id, fields="sheets/data/rowMetadata/hiddenByUser")
+        assert json['sheets'][0]['data'][0]['rowMetadata'][0].get('hiddenByUser', False) == False
+        assert json['sheets'][0]['data'][0]['rowMetadata'][1].get('hiddenByUser', False) == False
+
+    def test_hide_columns(self):
+        self.worksheet.hide_columns(0, 2)
+        json = self.spreadsheet.client.sh_get_ssheet(self.spreadsheet.id, fields="sheets/data/columnMetadata/hiddenByUser")
+        assert json['sheets'][0]['data'][0]['columnMetadata'][0]['hiddenByUser'] == True
+        assert json['sheets'][0]['data'][0]['columnMetadata'][1]['hiddenByUser'] == True
+        self.worksheet.show_columns(0, 2)
+        json =self.spreadsheet.client.sh_get_ssheet(self.spreadsheet.id, fields="sheets/data/columnMetadata/hiddenByUser")
+        assert json['sheets'][0]['data'][0]['columnMetadata'][0].get('hiddenByUser', False) == False
+        assert json['sheets'][0]['data'][0]['columnMetadata'][1].get('hiddenByUser', False) == False
+
 
 # @pytest.mark.skip()
 class TestCell(object):


### PR DESCRIPTION
Looks like there is no convinient way to fetch `row` or `col` data with the `pygsheets` methods. Had to implement online tests checks through the raw requests. May be it is time to think about taking Col and Row entities into the separate classes as like as `DataRange`?