### PR TITLE
Simple protected range support

### DIFF
--- a/pygsheets/datarange.py
+++ b/pygsheets/datarange.py
@@ -55,7 +55,6 @@ class DataRange(object):
         self._protect_id = protect_id
         self._name = name
 
-        self._protected = False
         self.protected_properties = ProtectedRange()
         self._banned = False
 

--- a/pygsheets/datarange.py
+++ b/pygsheets/datarange.py
@@ -29,7 +29,7 @@ class DataRange(object):
     :param namedjson: json representing the NamedRange from api
     """
 
-    def __init__(self, start=None, end=None, worksheet=None, name='', data=None, name_id=None, namedjson=None):
+    def __init__(self, start=None, end=None, worksheet=None, name='', data=None, name_id=None, namedjson=None, protect_id=None, protectedjson=None):
         self._worksheet = worksheet
         if namedjson:
             start = (namedjson['range'].get('startRowIndex', 0)+1, namedjson['range'].get('startColumnIndex', 0)+1)
@@ -37,6 +37,12 @@ class DataRange(object):
             end = (namedjson['range'].get('endRowIndex', self._worksheet.cols),
                    namedjson['range'].get('endColumnIndex', self._worksheet.rows))
             name_id = namedjson['namedRangeId']
+        if protectedjson:
+            start = (protectedjson['range'].get('startRowIndex', 0)+1, protectedjson['range'].get('startColumnIndex', 0)+1)
+            # @TODO this won't scale if the sheet size is changed
+            end = (protectedjson['range'].get('endRowIndex', self._worksheet.cols),
+                   protectedjson['range'].get('endColumnIndex', self._worksheet.rows))
+            protect_id = protectedjson['protectedRangeId']
         self._start_addr = format_addr(start, 'tuple')
         self._end_addr = format_addr(end, 'tuple')
         if data:
@@ -46,6 +52,7 @@ class DataRange(object):
         self._linked = True
 
         self._name_id = name_id
+        self._protect_id = protect_id
         self._name = name
 
         self._protected = False
@@ -81,17 +88,22 @@ class DataRange(object):
         return self._name_id
 
     @property
-    def protect(self):
-        """ (boolean) if this range is protected"""
-        return self._protected
+    def protect_id(self):
+        return self._protect_id
 
-    # @TODO
-    @protect.setter
-    def protect(self, value):
+    @property
+    def protected(self):
+        """get/set range protection"""
+        return self._protect_id is None
+
+    @protected.setter
+    def protected(self, value):
         if value:
-            self._worksheet.create_protected_range()
-        else:
-            self._worksheet.remove_protected_range()
+            resp = self._worksheet.create_protected_range(self._get_gridrange())
+            self._protect_id = resp['replies'][0]['addProtectedRange']['protectedRange']['protectedRangeId']
+        elif not self._protect_id is None:
+            self._worksheet.remove_protected_range(self._protect_id)
+            self._protect_id = None
 
     @property
     def start_addr(self):

--- a/pygsheets/datarange.py
+++ b/pygsheets/datarange.py
@@ -93,7 +93,7 @@ class DataRange(object):
     @property
     def protected(self):
         """get/set range protection"""
-        return self._protect_id is None
+        return self._protect_id is not None
 
     @protected.setter
     def protected(self, value):

--- a/pygsheets/spreadsheet.py
+++ b/pygsheets/spreadsheet.py
@@ -60,9 +60,18 @@ class Spreadsheet(object):
 
     @property
     def named_ranges(self):
-        """All named ranges in thi spreadsheet"""
+        """All named ranges in this spreadsheet"""
         return [DataRange(namedjson=x, name=x['name'], worksheet=self.worksheet('id', x['range'].get('sheetId', 0)))
                 for x in self._named_ranges]
+
+    @property
+    def protected_ranges(self):
+        """All protected ranges in this spreadsheet"""
+        request = self.client.service.spreadsheets().get(spreadsheetId=self.id, fields="sheets/(properties/sheetId,protectedRanges)", includeGridData=True)
+        response = self.client._execute_request(self.id, request, False)
+        return [DataRange(protectedjson=x, worksheet=self.worksheet('id', sheet['properties']['sheetId']))
+                for sheet in response['sheets']
+                for x in sheet.get('protectedRanges', [])]
 
     @property
     def defaultformat(self):

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -812,6 +812,24 @@ class Worksheet(object):
         self.client.sh_batch_update(self.spreadsheet.id, request, batch=self.spreadsheet.batch_mode)
         self.spreadsheet._named_ranges = [x for x in self.spreadsheet._named_ranges if x["namedRangeId"] != range_id]
 
+    def create_protected_range(self, gridrange):
+        """create protected range
+          :param gridrange: gridrange of cells to be protected"""
+        request = {"addProtectedRange": {
+            "protectedRange": {
+                "range": gridrange
+            },
+        }}
+        return self.client.sh_batch_update(self.spreadsheet.id, request, None, False)
+
+    def remove_protected_range(self, range_id):
+        """create protected range
+          :param range_id: id of protected range to be deleted"""
+        request = {"deleteProtectedRange": {
+            "protectedRangeId": range_id
+        }}
+        return self.client.sh_batch_update(self.spreadsheet.id, request, None, False)
+
     def set_dataframe(self, df, start, copy_index=False, copy_head=True, fit=False, escape_formulae=False, nan='NaN'):
         """
         set the values of a pandas dataframe at cell <start>

--- a/test/online_test.py
+++ b/test/online_test.py
@@ -408,10 +408,12 @@ class TestDataRange(object):
 
     def test_protected_range(self):
         self.range.protected = True
+        assert self.range.protected
         assert self.range.protect_id is not None
         assert self.range is not None
         assert len(self.spreadsheet.protected_ranges) == 1
         self.range.protected = False
+        assert not self.range.protected
         assert self.range.protect_id is None
         assert len(self.spreadsheet.protected_ranges) == 0
 

--- a/test/online_test.py
+++ b/test/online_test.py
@@ -395,6 +395,27 @@ class TestWorkSheet(object):
         assert self.worksheet.get_values('D1', 'D3', returnas="cells", include_all=True) == [[Cell('D1', '')], [Cell('D2', '')], [Cell('D3', '')]]
 
 
+class TestDataRange(object):
+    def setup_class(self):
+        title = config.get('Spreadsheet', 'title')
+        self.spreadsheet = gc.create(title)
+        self.worksheet = self.spreadsheet.worksheet()
+        self.range = self.worksheet.range("A1:A2", returnas="range")
+
+    def teardown_class(self):
+        title = config.get('Spreadsheet', 'title')
+        gc.delete(title=title)
+
+    def test_protected_range(self):
+        self.range.protected = True
+        assert self.range.protect_id is not None
+        assert self.range is not None
+        assert len(self.spreadsheet.protected_ranges) == 1
+        self.range.protected = False
+        assert self.range.protect_id is None
+        assert len(self.spreadsheet.protected_ranges) == 0
+
+
 # @pytest.mark.skip()
 class TestCell(object):
     def setup_class(self):


### PR DESCRIPTION
Hi, here is a simple protected range implementation. 

- `DataRange.protect = True` 
  - creates protected range by `gridrange`,
  - remembers protect_id in `DataRange`. 
- `DataRange.protect = False` 
  - removes protected range by saved `protect_id`,
  - flushes protect_id from `DataRange`.
-  `Spreadsheet.protected_ranges`
  - queries `GS API` for known protected ranges
  - created list protected of `DataRange` to use for deletion

I think we shouldn't do extra job with updating all known objects as you are trying to do with named implementation. As for me it quite suitable to remember last state in the changed object and use methods like protected_ranges and named_ranges just to query actual situation.