### PR TITLE
Attempt to fix TypeError: 'filter' object is not subscriptable in find()

### DIFF
--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -285,7 +285,7 @@ class Worksheet(object):
                 values = [x.get('values', []) for x in values]
             else:
                 values = [x.get('values', []) for x in values]
-                values = filter(lambda x: any('effectiveValue' in item for item in x), values)  # skip empty rows
+                values = list(filter(lambda x: any('effectiveValue' in item for item in x), values))  # skip empty rows
             empty_value = dict()
 
         if values == [['']] or values == []: values = [[]]
@@ -301,13 +301,13 @@ class Worksheet(object):
                 matrix.extend([[empty_value]*max_cols]*(max_rows - len(matrix)))
         elif include_empty and len(values) > 0 and values != [[]]:
             if returnas != "matrix":
-                matrix = filter(lambda x: any('effectiveValue' in item for item in x), values)  # skip empty rows
+                matrix = list(filter(lambda x: any('effectiveValue' in item for item in x), values))  # skip empty rows
             else:
                 max_cols = end[1] - start[1] + 1 if majdim == "ROWS" else end[0] - start[0] + 1
                 matrix = [list(x + [empty_value] * (max_cols - len(x))) for x in values]
         else:
             if returnas != "matrix":
-                matrix = filter(lambda x: any('effectiveValue' in item for item in x), values)  # skip empty rows
+                matrix = list(filter(lambda x: any('effectiveValue' in item for item in x), values))  # skip empty rows
                 for i, row in enumerate(matrix):
                     for j, cell in reversed(list(enumerate(row))):
                         if 'effectiveValue' not in cell:


### PR DESCRIPTION
Python 3.6.4 (miniconda)
Windows 10 x64

Error:
```
  File "J:\ys\test.py", line 50, in sheetsupdate
    cell_list = wks.find('abc')
  File "j:\miniconda3\envs\ys\lib\site-packages\pygsheets\worksheet.py", line 754, in find
    self._update_grid(force_fetch)
  File "j:\miniconda3\envs\ys\lib\site-packages\pygsheets\worksheet.py", line 143, in _update_grid
    self.data_grid = self.get_all_values(returnas='cells', include_empty=False)
  File "j:\miniconda3\envs\ys\lib\site-packages\pygsheets\worksheet.py", line 359, in get_all_values
    majdim=majdim, include_empty=include_empty)
  File "j:\miniconda3\envs\ys\lib\site-packages\pygsheets\worksheet.py", line 314, in get_values
    del matrix[i][j]
TypeError: 'filter' object is not subscriptable
```

`filter()` in Python 3 returns an iterator. Added `list()` to return a list of cells instead.

Not sure if it breaks anything else but seems to work:

After fix:
```
[<Cell A5 'abc'>, <Cell B6 'abc'>, <Cell F7 'abc'>]
```