### PR TITLE
Autoresize bindings

### DIFF
--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -697,6 +697,42 @@ class Worksheet(object):
 
         self.client.sh_batch_update(self.spreadsheet.id, request, batch=self.spreadsheet.batch_mode)
 
+    def auto_resize_dimensions(self, dimension, start, end=None):
+        """Automatically resizes one or more dimensions
+        :param dimension: COLUMNS or ROWS
+        :param start: index of dimension to be resized
+        :param end: index of dimension that will be resized
+        """
+        if end is None or end <= start:
+            end = start + 1
+
+        request = {
+          "autoResizeDimensions": {
+            "dimensions": {
+              "sheetId": self.id,
+              "dimension": dimension,
+              "startIndex": start,
+              "endIndex": end
+            }
+          }
+        },
+        self.client.sh_batch_update(self.spreadsheet.id, request, batch=self.spreadsheet.batch_mode)
+        return self
+
+    def auto_resize_columns(self, start, end=None):
+        """Automatically resizes one or more columns
+        :param start: index of column to be resized
+        :param end: index of column that will be resized
+        """
+        self.auto_resize_dimensions('COLUMNS', start, end)
+
+    def auto_resize_rows(self, start, end=None):
+        """Automatically resizes one or more rows
+        :param start: index of row to be resized
+        :param end: index of row that will be resized
+        """
+        self.auto_resize_dimensions('ROWS', start, end)
+
     def update_dimensions_visibility(self, start, end=None, dimension="ROWS", hidden=True):
         """Set visibility of dimensions
 

--- a/test/online_test.py
+++ b/test/online_test.py
@@ -428,6 +428,15 @@ class TestWorkSheet(object):
         assert json['sheets'][0]['data'][0]['columnMetadata'][0].get('hiddenByUser', False) == False
         assert json['sheets'][0]['data'][0]['columnMetadata'][1].get('hiddenByUser', False) == False
 
+    def test_cols_autoresize(self):
+        self.worksheet.update_cells(crange='A1:B1', values=[['short', 'loooooooong']])
+        self.worksheet.auto_resize_columns(0, 2)
+        json = self.spreadsheet.client.sh_get_ssheet(self.spreadsheet.id, fields="sheets/data/columnMetadata/pixelSize")
+        a = json['sheets'][0]['data'][0]['columnMetadata'][0]
+        b = json['sheets'][0]['data'][0]['columnMetadata'][1]
+        assert 100 not in [a, b]
+        assert a != b
+
 
 class TestDataRange(object):
     def setup_class(self):

--- a/test/online_test.py
+++ b/test/online_test.py
@@ -437,6 +437,21 @@ class TestWorkSheet(object):
         assert 100 not in [a, b]
         assert a != b
 
+    def test_rows_autoresize(self):
+        self.worksheet.update_cells(crange='A1:A2', values=[['row'], ['twoooooooooo rooooooooows']])
+        format = Cell("A1")
+        format.set_text_format('fontSize', 60)
+        format.wrap_strategy = "WRAP"
+        self.worksheet.range("A2:A2", returnas="range").apply_format(format)
+        self.worksheet.adjust_row_height(1, pixel_size=200)
+        _json = self.spreadsheet.client.sh_get_ssheet(self.spreadsheet.id, fields="sheets/data/rowMetadata/pixelSize")
+        _row2 = _json['sheets'][0]['data'][0]['rowMetadata'][1]['pixelSize']
+        self.worksheet.auto_resize_rows(0, 3)
+        json = self.spreadsheet.client.sh_get_ssheet(self.spreadsheet.id, fields="sheets/data/rowMetadata/pixelSize")
+        row2 = json['sheets'][0]['data'][0]['rowMetadata'][1]['pixelSize']
+        assert _row2 == 200
+        assert row2 == 21
+
 
 class TestDataRange(object):
     def setup_class(self):


### PR DESCRIPTION
Here is the implementation of `autoResizeDimensions` method. Unfortunately it doesn't work well due to google server side reasons. MTT I was unable make suitable row autoresize tests, because auto-resized row always gets `21px` height for some reason.