### PR TITLE
A little bit more compatibility into the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 TEST_PATH=./online_test.py
 
 clean-pyc:
-	find . -name '*.pyc' -exec rm --force {} +
-	find . -name '*.pyo' -exec rm --force {} +
-	find . -name '*~' -exec rm --force  {} +
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f  {} +
 	find . -name '__pycache__' -exec rm -rf {} +
 
 clean-build:


### PR DESCRIPTION
Unfortunately my mac `rm` command doesn't support `--force` flag. As I know `-f` persist everywhere, won't you be so kind to make it more compatible?