### PR TITLE
Move windows cache path check to no_cache=False block

### DIFF
--- a/pygsheets/client.py
+++ b/pygsheets/client.py
@@ -65,8 +65,8 @@ class Client(object):
             cache = None
         else:
             cache = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
-        if os.name == "nt":
-            cache = "\\\\?\\" + cache
+            if os.name == "nt":
+                cache = "\\\\?\\" + cache
 
         self.oauth = oauth
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
This was causing an error:
```
    cache = "\\\\?\\" + cache
TypeError: must be str, not NoneType
```
when passing `no_cache=True`.