### PR TITLE
Rollback copy for worksheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ wks.index = 2 # index start at 1 , not 0
 # Update title
 wks.title = "NewTitle"
 
+# Update hidden state
+wks.hidden = False
+
 # working with named ranges
 wks.create_named_range('A1', 'A10', 'prices')
 wks.get_named_range('prices')

--- a/pygsheets/spreadsheet.py
+++ b/pygsheets/spreadsheet.py
@@ -194,13 +194,13 @@ class Spreadsheet(object):
 
         jsheet = dict()
         if src_tuple:
-            jsheet['properties'] = self.client.sheet.sheets_to_copy(src_tuple[0], src_tuple[1], self.id)
+            jsheet['properties'] = self.client.sh_copy_worksheet(src_tuple[0], src_tuple[1], self.id)
             wks = self.worksheet_cls(self, jsheet)
             wks.title = title
         elif src_worksheet:
             if type(src_worksheet) != Worksheet:
                 raise InvalidArgumentValue("src_worksheet")
-            jsheet['properties'] = self.client.sheet.sheets_to_copy(src_worksheet.spreadsheet.id, src_worksheet.id, self.id)
+            jsheet['properties'] = self.client.sh_copy_worksheet(src_worksheet.spreadsheet.id, src_worksheet.id, self.id)
             wks = self.worksheet_cls(self, jsheet)
             wks.title = title
         else:

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -75,6 +75,17 @@ class Worksheet(object):
             self.client.sheet.update_sheet_properties_request(self.spreadsheet.id, self.jsonSheet['properties'], 'title')
 
     @property
+    def hidden(self):
+        """Mark the worksheet as hidden."""
+        return self.jsonSheet['properties']['hidden']
+
+    @hidden.setter
+    def hidden(self, hidden):
+        self.jsonSheet['properties']['hidden'] = hidden
+        if self._linked:
+            self.client.sheet.update_sheet_properties_request(self.spreadsheet.id, self.jsonSheet['properties'], 'hidden')
+
+    @property
     def url(self):
         """The url of this worksheet."""
         return self.spreadsheet.url+"/edit#gid="+str(self.id)

--- a/test/data/spreadsheet.json
+++ b/test/data/spreadsheet.json
@@ -37,6 +37,7 @@
     "sheetId": 0,
     "title": "Sheet1",
     "index": 0,
+    "hidden": false,
     "sheetType": "GRID",
     "gridProperties": {
      "rowCount": 30,
@@ -49,6 +50,7 @@
     "sheetId": 222677309,
     "title": "pySheet2",
     "index": 1,
+    "hidden": false,
     "sheetType": "GRID",
     "gridProperties": {
      "rowCount": 1000,
@@ -61,6 +63,7 @@
     "sheetId": 45743359,
     "title": "xxxx",
     "index": 2,
+    "hidden": false,
     "sheetType": "GRID",
     "gridProperties": {
      "rowCount": 1000,


### PR DESCRIPTION
Fixes issue: https://github.com/nithinmurali/pygsheets/issues/250

Please @Kordishal let me know if this is OK, or actually it's not necessary, but I'm having issues with the code in staging.

Anyway this doesn't work at all. Now the error is: `AttributeError: 'Client' object has no attribute 'sh_copy_worksheet'`

I'm migrating to python 3 and start again with this issue.