### PR TITLE
Set 'transferOwnership' flag to true in case role is 'owner'

### DIFF
--- a/pygsheets/drive.py
+++ b/pygsheets/drive.py
@@ -287,6 +287,9 @@ class DriveAPIWrapper(object):
             body['expirationTime'] = kwargs['expirationTime']
             del kwargs['expirationTime']
 
+        if role.lower() == 'owner':
+            kwargs['transferOwnership'] = True
+
         return self._execute_request(self.service.permissions().create(fileId=file_id, body=body, **kwargs))
 
     def list_permissions(self, file_id, **kwargs):


### PR DESCRIPTION
When creating a new spreadsheet and calling `spreadsheet.share` with the role equal to `owner`, the Google API returns a `HTTP Error 403: "The transferOwnership parameter must be enabled when the permission role is 'owner'."`

This PR fixes this issue and sets the `transferOwnership` flag to `True` if the role is equal to `owner`