### PR TITLE
Add **kwargs to spreadsheet.delete()

### DIFF
--- a/pygsheets/drive.py
+++ b/pygsheets/drive.py
@@ -133,6 +133,9 @@ class DriveAPIWrapper(object):
         :param file_id:     The Id of the file to be deleted.
         :param kwargs:      Standard parameters (see documentation for details).
         """
+        if 'supportsTeamDrives' not in kwargs and self.team_drive_id:
+            kwargs['supportsTeamDrives'] = True
+
         self._execute_request(self.service.files().delete(fileId=file_id, **kwargs))
 
     def move_file(self, file_id, old_folder, new_folder, **kwargs):

--- a/pygsheets/drive.py
+++ b/pygsheets/drive.py
@@ -178,7 +178,7 @@ class DriveAPIWrapper(object):
         """The export request."""
         return self.service.files().export(fileId=file_id, mimeType=mime_type, **kwargs)
 
-    def export(self, sheet, file_format, path='', filename=None):
+    def export(self, sheet, file_format, path='', filename=''):
         """Download a spreadsheet and store it.
 
          Exports a Google Doc to the requested MIME type and returns the exported content.

--- a/pygsheets/spreadsheet.py
+++ b/pygsheets/spreadsheet.py
@@ -319,21 +319,13 @@ class Spreadsheet(object):
         """
         self.client.drive.export(self, file_format=file_format, filename=filename, path=path)
 
-    def delete(self, **kwargs):
+    def delete(self):
         """Deletes this spreadsheet.
 
         Leaves the local copy intact. The deleted spreadsheet is permanently removed from your drive
         and not moved to the trash.
-        
-        Delete a file in a TeamDrive.
-        
-        >>> spreadsheet.delete(supportsTeamDrives=True)
-        
-        Reference: `delete request <https://developers.google.com/drive/v3/reference/files/delete>`__
-        
-        :param kwargs:      Standard parameters (see documentation for details).
         """
-        self.client.drive.delete(self.id, **kwargs)
+        self.client.drive.delete(self.id)
 
     def custom_request(self, request, fields, **kwargs):
         """

--- a/pygsheets/spreadsheet.py
+++ b/pygsheets/spreadsheet.py
@@ -319,13 +319,21 @@ class Spreadsheet(object):
         """
         self.client.drive.export(self, file_format=file_format, filename=filename, path=path)
 
-    def delete(self):
+    def delete(self, **kwargs):
         """Deletes this spreadsheet.
 
         Leaves the local copy intact. The deleted spreadsheet is permanently removed from your drive
         and not moved to the trash.
+        
+        Delete a file in a TeamDrive.
+        
+        >>> spreadsheet.delete(supportsTeamDrives=True)
+        
+        Reference: `delete request <https://developers.google.com/drive/v3/reference/files/delete>`__
+        
+        :param kwargs:      Standard parameters (see documentation for details).
         """
-        self.client.drive.delete(self.id)
+        self.client.drive.delete(self.id, **kwargs)
 
     def custom_request(self, request, fields, **kwargs):
         """

--- a/pygsheets/spreadsheet.py
+++ b/pygsheets/spreadsheet.py
@@ -306,7 +306,7 @@ class Spreadsheet(object):
                 if email_or_domain in [permission.get('domain', ''), permission.get('emailAddress', '')]:
                     self.client.drive.delete_permission(self.id, permission_id=permission['id'])
 
-    def export(self, file_format=ExportType.CSV, path='', filename=None):
+    def export(self, file_format=ExportType.CSV, path='', filename=''):
         """Export all worksheets.
 
         The filename must have an appropriate file extension. Each sheet will be exported into a separate file.


### PR DESCRIPTION
Without this fix, I get a `googleapiclient.errors.HttpError` 404 error that the requested spreadsheet doesn't exist, even after enabling Team Drive with:

```
gc = pygsheets.authorize()
if teamDriveID:
    gc.drive.enable_team_drive(teamDriveID)

spreadsheet = gc.open_by_url(sheetURL)    # Spreadsheet was found via Sheets API v4
spreadsheet.delete()                      # HTTP 404 Error raised here via Drive API v3
```

I worked around this by using:

```
gc.drive.delete(spreadsheet.id, supportsTeamDrives=True)
```

But it would be nice to use this on the spreadsheet object like much of the other API wrapper functions like so:

```
spreadsheet.delete(supportsTeamDrives=True)
```