### PR TITLE
Fix duplicate file extension output in logging

### DIFF
--- a/pygsheets/drive.py
+++ b/pygsheets/drive.py
@@ -221,7 +221,7 @@ class DriveAPIWrapper(object):
         while done is False:
             status, done = downloader.next_chunk()
             # logging.info('Download progress: %d%%.', int(status.progress() * 100)) TODO fix this
-        logging.info('Download finished. File saved in %s.', path + file_name + file_extension)
+        logging.info('Download finished. File saved in %s.', path + file_name)
 
         if tmp is not None:
             sheet.index = tmp


### PR DESCRIPTION
Remove duplicate file_extension in log output. 

```
logging.info('Download finished. File saved in %s.', path + file_name + file_extension)
>>> logging.info('Download finished. File saved in %s.', path + file_name)
```

Example:
```
2019-04-08 10:36:26 - root - INFO - Download finished. File saved in 0.csv.csv.
2019-04-08 10:36:28 - root - INFO - Download finished. File saved in 1.csv.csv.
2019-04-08 10:36:29 - root - INFO - Download finished. File saved in 2.csv.csv.
```

`.csv` is being duplicated because it's in the `file_name` as well from this line:

```
file_name = str(sheet.id) + file_extension if filename is None else filename + file_extension
```