### PR TITLE
Small fix on instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ wks.update_value('A1', "Hey yank this numpy array")
 my_nparray = np.random.randint(10, size=(3, 4))
 
 # update the sheet with array
-wks.update_values('A2', my_nparray.to_list())
+wks.update_values('A2', my_nparray.tolist())
 
 # share the sheet with your friend
 sh.share("myFriend@gmail.com")


### PR DESCRIPTION
The method to make a numpy array a list is `tolist`, the instructions have `to_list`, which does not run