### PR TITLE
Environment variable support for Service Account credentials

### DIFF
--- a/docs/source/authorization.rst
+++ b/docs/source/authorization.rst
@@ -115,9 +115,18 @@ This is how this file may look like::
         "client_id": "10.....454",
     }
 
-7. The authorization process can be completed without any further interactions::
+8. The authorization process can be completed without any further interactions::
 
     gc = pygsheets.authorize(service_file='path/to/service_account_credentials.json')
+
+Environment Variables
+---------------------
+
+For services like Heroku that recommend using [Twelve-Factor App principles](https://12factor.net/), e.g. for storing config data in the environment instead of files, you can pass in Service Account credentials via an environment variable::
+
+    gc = pygsheets.authorize(service_account_env_var = 'GDRIVE_API_CREDENTIALS')
+
+This assumes you have set an environment variable key `GDRIVE_API_CREDENTIALS` set with the value of the Service Account .json file described in the above Service Account section.
 
 Custom Credentials Objects
 --------------------------

--- a/pygsheets/authorization.py
+++ b/pygsheets/authorization.py
@@ -71,6 +71,7 @@ _deprecated_keyword_mapping = {
 
 def authorize(client_secret='client_secret.json',
               service_account_file=None,
+              service_account_env_var=None,
               credentials_directory='',
               scopes=_SCOPES,
               custom_credentials=None,
@@ -82,6 +83,7 @@ def authorize(client_secret='client_secret.json',
 
     :param client_secret:           Location of the oauth2 credentials file.
     :param service_account_file:    Location of a service account file.
+    :param service_account_env_var: Use an environment variable to provide service account credentials.
     :param credentials_directory:   Location of the token file created by the OAuth2 process. Use 'global' to store in
                                     global location, which is OS dependent. Default None will store token file in
                                     current working directory. Please note that this is override your client secret.
@@ -107,6 +109,10 @@ def authorize(client_secret='client_secret.json',
 
     if custom_credentials is not None:
         credentials = custom_credentials
+    elif service_account_env_var is not None:
+        service_account_info = json.loads(os.environ[service_account_env_var])
+        credentials = service_account.Credentials.from_service_account_info(
+        service_account_info, scopes=scopes)
     elif service_account_file is not None:
         credentials = service_account.Credentials.from_service_account_file(service_account_file, scopes=scopes)
     else:


### PR DESCRIPTION
As an alternative to `pygsheets.authorize(service_file='credentials.json')`

Inspired by [this Stack Overflow thread](https://stackoverflow.com/questions/54797849/problem-accessing-google-api-environment-variable-in-heroku).