### PR TITLE
Fixes an IndexError when retrieving ranges of cells from a spreadsheet

### DIFF
--- a/pygsheets/cell.py
+++ b/pygsheets/cell.py
@@ -500,7 +500,7 @@ class Cell(object):
         self._value = cell_data.get('formattedValue', '')
         try:
             self._unformated_value = list(cell_data['effectiveValue'].values())[0]
-        except KeyError:
+        except (KeyError, IndexError):
             self._unformated_value = ''
         self._formula = cell_data.get('userEnteredValue', {}).get('formulaValue', '')
 


### PR DESCRIPTION
It appears Google recently changed the Spreadsheets API to return an empty list under the `effectiveValue` key instead of simply not including the key when a cell has no raw value, which was causing IndexErrors when trying to access the first element of that list. This change catches that case.