### PR TITLE
enabled text rotation

### DIFF
--- a/pygsheets/cell.py
+++ b/pygsheets/cell.py
@@ -480,6 +480,8 @@ class Cell(object):
             ret_json["userEnteredFormat"]["verticalAlignment"] = self._vertical_alignment.value
         if self._wrap_strategy is not None:
             ret_json["userEnteredFormat"]["wrapStrategy"] = self._wrap_strategy
+        if self.text_rotation is not None:
+            ret_json["userEnteredFormat"]["textRotation"] = self.text_rotation
 
         if self._note is not None:
             ret_json["note"] = self._note


### PR DESCRIPTION
I had the issue described here:
https://stackoverflow.com/questions/56641290/how-do-i-rotate-text-in-a-google-sheet-using-pygsheets/56642629#56642629

Basically these calls did not rotate the text as expected
```
header2 = wks.cell('B1')
header2.value = '45 Degree rotated text'
header2.set_text_rotation('angle', 45)
header2.update()

header3 = wks.cell('C1')
header3.value = 'Vertical Text'
header3.set_text_rotation('vertical', True)
header3.update()
```
This PR has the fix suggested in the SO link.