### PR TITLE
Address and Grid Range

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,4 +20,4 @@ formats: all
 python:
   version: 3.7
   install:
-    - requirements: docs/requirements.txt
+    - requirements: docs/source/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.6
   install:
     - requirements: docs/source/requirements.txt

--- a/docs/source/address.rst
+++ b/docs/source/address.rst
@@ -1,0 +1,13 @@
+
+.. _address:
+
+Address
+=======
+
+.. module:: pygsheets
+
+.. autoclass:: Address
+   :members:
+
+.. autoclass:: GridRange
+   :members:

--- a/docs/source/authorization.rst
+++ b/docs/source/authorization.rst
@@ -3,7 +3,7 @@ Authorizing pygsheets
 
 There are multiple ways to authorize google sheets. First you should create a developer account (follow below steps) and
 create the type of credentials depending on your need. These credentials give the python script access to a google account.
- But remember not to give away any of these credentials, as your usage quota is limited.
+But remember not to give away any of these credentials, as your usage quota is limited.
 
 
 1. Head to `Google Developers Console <https://console.developers.google.com>`_ and create a new project (or select the one you have.)

--- a/docs/source/custom_types.rst
+++ b/docs/source/custom_types.rst
@@ -1,0 +1,7 @@
+
+.. _custom_types:
+
+Custom Types
+============
+
+.. module:: pygsheets.custom_types

--- a/docs/source/custom_types.rst
+++ b/docs/source/custom_types.rst
@@ -4,4 +4,6 @@
 Custom Types
 ============
 
-.. module:: pygsheets.custom_types
+.. automodule:: pygsheets.custom_types
+   :members:
+   :undoc-members:

--- a/docs/source/datarange.rst
+++ b/docs/source/datarange.rst
@@ -4,7 +4,7 @@
 DataRange
 =========
 
-.. module:: pygsheets
+.. module:: pygsheets.datarange
 
 .. autoclass:: DataRange
    :members:

--- a/docs/source/drive_api.rst
+++ b/docs/source/drive_api.rst
@@ -1,5 +1,5 @@
 
-.. _drive_api_wrapper:
+.. _drive_api:
 
 Drive API Wrapper
 =================

--- a/docs/source/drive_api.rst
+++ b/docs/source/drive_api.rst
@@ -1,5 +1,5 @@
 
-.. _drive_api:
+.. _drive_api_wrapper:
 
 Drive API Wrapper
 =================

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -2,14 +2,18 @@
 Examples
 ========
 
-**Batching of api calls**::
+**Batching of api calls**
+
+.. code:: python
 
     wks.unlink()
     for i in range(10):
         wks.update_value((1, i), i) # wont call api
     wks.link() # will do all the updates
 
-**Protect an whole sheet**::
+**Protect an whole sheet**
+
+.. code:: python
 
     r = Datarange(worksheet=wks)
     >>> r # this is a datarange unbounded on both indexes
@@ -19,7 +23,9 @@ Examples
 
 **Formatting columns**
 column A as percentage format, column B as currency format. Then formatting
-row 1 as white , row 2 as grey colour. ::
+row 1 as white , row 2 as grey colour. By @cwdjankoski
+
+.. code:: python
 
     model_cell = pygsheets.Cell("A1")
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,0 +1,49 @@
+
+Examples
+========
+
+**Batching of api calls**::
+
+    wks.unlink()
+    for i in range(10):
+        wks.update_value((1, i), i) # wont call api
+    wks.link() # will do all the updates
+
+**Protect an whole sheet**::
+
+    r = Datarange(worksheet=wks)
+    >>> r # this is a datarange unbounded on both indexes
+    <Datarange Sheet1>
+    >>> r.protected = True # this will make the whole sheet protected
+
+
+**Formatting columns**
+column A as percentage format, column B as currency format. Then formatting
+row 1 as white , row 2 as grey colour. ::
+
+    model_cell = pygsheets.Cell("A1")
+
+    model_cell.set_number_format(
+        format_type = pygsheets.FormatType.PERCENT,
+        pattern = "0%"
+    )
+    # first apply the percentage formatting
+    pygsheets.DataRange(
+        left_corner_cell , right_corner_cell , worksheet = wks
+     ).apply_format(model_cell)
+
+    # now apply the row-colouring interchangeably
+    gray_cell = pygsheets.Cell("A1")
+    gray_cell.color = (0.9529412, 0.9529412, 0.9529412, 0)
+
+    white_cell = pygsheets.Cell("A2")
+    white_cell.color = (1, 1, 1, 0)
+
+    cells = [gray_cell, white_cell]
+
+    for r in range(start_row, end_row + 1):
+        print(f"Doing row {r} ...", flush = True, end = "\r")
+        wks.get_row(r, returnas = "range").apply_format(cells[ r % 2 ], fields = "userEnteredFormat.backgroundColor")
+
+**Note**:
+If you have any intresting examples that you think will be helpful to others, please raise a PR or issue.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -118,8 +118,9 @@ Contents:
 
    authorization
    reference
-   changelog
+   examples
    tips
+   changelog
 
 
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -41,20 +41,26 @@ Python objects for the main Google Sheets API Resources: :class:`spreadsheet <Sp
    spreadsheet
    worksheet
    datarange
+   address
    cell
    chart
 
+Custom Types
+------------
+
+There are many Enums defined for model properties or function parameters.
+
+.. toctree::
+
+   custom_types
+
+
 API Wrappers
----
+------------
 
 The Drive API is wrapped by :class:`DriveAPIWrapper <DriveAPIWrapper>`, and the Sheets API is wrapped
 by :class:`SheetAPIWrapper <SheetAPIWrapper>`. They Only implements functionality used by this package.
 You would never need to access this directly.
-
-.. toctree::
-
-   drive_api
-   sheet_api
 
 
 Exceptions

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -45,22 +45,22 @@ Python objects for the main Google Sheets API Resources: :class:`spreadsheet <Sp
    cell
    chart
 
-Custom Types
-------------
-
-There are many Enums defined for model properties or function parameters.
-
-.. toctree::
-
-   custom_types
 
 
-API Wrappers
-------------
+Helper Classes
+--------------
 
 The Drive API is wrapped by :class:`DriveAPIWrapper <DriveAPIWrapper>`, and the Sheets API is wrapped
 by :class:`SheetAPIWrapper <SheetAPIWrapper>`. They Only implements functionality used by this package.
 You would never need to access this directly.
+
+Also there are many Enums defined for model properties or function parameters.
+
+.. toctree::
+
+   custom_types
+   sheet_api
+   drive_api
 
 
 Exceptions

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,3 @@
+google-auth-oauthlib
+oauth2client
+google-api-python-client

--- a/docs/source/sheet_api.rst
+++ b/docs/source/sheet_api.rst
@@ -1,5 +1,5 @@
 
-.. _sheet_api_wrapper:
+.. _sheet_api:
 
 Sheet API Wrapper
 =================

--- a/docs/source/sheet_api.rst
+++ b/docs/source/sheet_api.rst
@@ -1,5 +1,5 @@
 
-.. _sheet_api:
+.. _sheet_api_wrapper:
 
 Sheet API Wrapper
 =================

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -20,3 +20,14 @@ Conversion of sheet data
 usually all the values are converted to string while using `get_*` functions. But if you want then to retain
 their type, the change the `value_render` option to ValueRenderOption.UNFORMATTED_VALUE.
 
+
+Examples
+--------
+
+Batching of api calls::
+
+    wks.unlink()
+    for i in range(10):
+        wks.update_value((1, i), i) # wont call api
+    wks.link() # will do all the updates
+

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -18,16 +18,5 @@ Access sheets by id::
 Conversion of sheet data
 
 usually all the values are converted to string while using `get_*` functions. But if you want then to retain
-their type, the change the `value_render` option to ValueRenderOption.UNFORMATTED_VALUE.
-
-
-Examples
---------
-
-Batching of api calls::
-
-    wks.unlink()
-    for i in range(10):
-        wks.update_value((1, i), i) # wont call api
-    wks.link() # will do all the updates
+their type, the change the `value_render` option to `ValueRenderOption.UNFORMATTED_VALUE`.
 

--- a/pygsheets/__init__.py
+++ b/pygsheets/__init__.py
@@ -16,7 +16,7 @@ from pygsheets.spreadsheet import Spreadsheet
 from pygsheets.worksheet import Worksheet
 from pygsheets.cell import Cell
 from pygsheets.datarange import DataRange
-from pygsheets.grid_range import GridRange, Address
+from pygsheets.address import GridRange, Address
 from pygsheets.chart import Chart
 from pygsheets.utils import format_addr
 from pygsheets.custom_types import (FormatType, WorkSheetProperty, DateTimeRenderOption,

--- a/pygsheets/__init__.py
+++ b/pygsheets/__init__.py
@@ -16,6 +16,7 @@ from pygsheets.spreadsheet import Spreadsheet
 from pygsheets.worksheet import Worksheet
 from pygsheets.cell import Cell
 from pygsheets.datarange import DataRange
+from pygsheets.grid_range import GridRange, Address
 from pygsheets.chart import Chart
 from pygsheets.utils import format_addr
 from pygsheets.custom_types import (FormatType, WorkSheetProperty, DateTimeRenderOption,

--- a/pygsheets/address.py
+++ b/pygsheets/address.py
@@ -9,19 +9,19 @@ class Address(object):
     requires explict setting of param `allow_non_single`.
     Integer Indexes start from 1.
 
-    >>> a = Address('A1')
+    >>> a = Address('A2')
     >>> a.label
-    A1
+    A2
     >>> a[0]
     1
     >>> a[1]
-    1
-    >>> a = Address((1, 1))
+    2
+    >>> a = Address((1, 2))
     >>> a.label
-    A1
+    A2
     >>> a + (0,1)
-    <Address B1>
-    >>> a == (1, 1)
+    <Address B2>
+    >>> a == (2, 2)
     True
     """
 

--- a/pygsheets/cell.py
+++ b/pygsheets/cell.py
@@ -11,6 +11,7 @@ This module represents a cell within the worksheet.
 from pygsheets.custom_types import *
 from pygsheets.exceptions import (IncorrectCellLabel, CellNotFound, InvalidArgumentValue)
 from pygsheets.utils import format_addr, is_number, format_color
+from pygsheets.grid_range import Address, GridRange
 
 
 class Cell(object):
@@ -28,10 +29,13 @@ class Cell(object):
 
     def __init__(self, pos, val='', worksheet=None, cell_data=None):
         self._worksheet = worksheet
-        if type(pos) == str:
-            pos = format_addr(pos, 'tuple')
-        self._row, self._col = pos
-        self._label = format_addr(pos, 'label')
+
+        # if type(pos) == str:
+        #     pos = format_addr(pos, 'tuple')
+        # self._row, self._col = pos
+        # self._label = format_addr(pos, 'label')
+        self._address = Address(pos, False)
+
         self._value = val  # formatted value
         self._unformated_value = val  # un-formatted value
         self._formula = ''
@@ -65,44 +69,42 @@ class Cell(object):
     @property
     def row(self):
         """Row number of the cell."""
-        return self._row
+        return self.address.row
 
     @row.setter
     def row(self, row):
-        if self._linked:
-            ncell = self._worksheet.cell((row, self.col))
-            self.__dict__.update(ncell.__dict__)
-        else:
-            self._row = row
-            self._label = format_addr((self._row, self._col), 'label')
+        self.address = (row, self.col)
 
     @property
     def col(self):
         """Column number of the cell."""
-        return self._col
+        return self.address.col
 
     @col.setter
     def col(self, col):
-        if self._linked:
-            ncell = self._worksheet.cell((self._row, col))
-            self.__dict__.update(ncell.__dict__)
-        else:
-            self._col = col
-            self._label = format_addr((self._row, self._col), 'label')
+        self.address = (self.row, col)
 
     @property
     def label(self):
         """This cells label (e.g. 'A1')."""
-        return self._label
+        return self.address.label
 
     @label.setter
     def label(self, label):
+        self.address = label
+
+    @property
+    def address(self):
+        """ Address object representing the cell location. """
+        return self._address
+
+    @address.setter
+    def address(self, value):
         if self._linked:
-            ncell = self._worksheet.cell(label)
+            ncell = self._worksheet.cell(value)
             self.__dict__.update(ncell.__dict__)
         else:
-            self._label = label
-            self._row, self._col = format_addr(label, 'tuple')
+            self._address = Address(value)
 
     @property
     def value(self):
@@ -413,7 +415,7 @@ class Cell(object):
             if "bottom" in position:
                 addr[0] += 1
         try:
-            ncell = self._worksheet.cell(tuple(addr))
+            ncell = self._worksheet.cell(addr)
         except IncorrectCellLabel:
             raise CellNotFound
         return ncell
@@ -455,13 +457,7 @@ class Cell(object):
         worksheet_id = worksheet_id if worksheet_id is not None else self._worksheet.id
         request = {
             "repeatCell": {
-                "range": {
-                    "sheetId": worksheet_id,
-                    "startRowIndex": self.row - 1,
-                    "endRowIndex": self.row,
-                    "startColumnIndex": self.col - 1,
-                    "endColumnIndex": self.col
-                },
+                "range": GridRange(start=self._address, end=self._address, worksheet_id=worksheet_id).to_json(),
                 "cell": self.get_json(),
                 "fields": "userEnteredFormat, note, userEnteredValue"
             }

--- a/pygsheets/cell.py
+++ b/pygsheets/cell.py
@@ -11,7 +11,7 @@ This module represents a cell within the worksheet.
 from pygsheets.custom_types import *
 from pygsheets.exceptions import (IncorrectCellLabel, CellNotFound, InvalidArgumentValue)
 from pygsheets.utils import format_addr, is_number, format_color
-from pygsheets.grid_range import Address, GridRange
+from pygsheets.address import Address, GridRange
 
 
 class Cell(object):
@@ -148,7 +148,7 @@ class Cell(object):
     @property
     def horizontal_alignment(self):
         """Horizontal alignment of the value in this cell.
-           possible vlaues: :class:`cell <HorizontalAlignment> """
+           possible vlaues: :class:`HorizontalAlignment <HorizontalAlignment>` """
         self.update()
         return self._horizontal_alignment
 
@@ -163,7 +163,7 @@ class Cell(object):
     @property
     def vertical_alignment(self):
         """Vertical alignment of the value in this cell.
-            possible vlaues: :class:`cell <VerticalAlignment> """
+            possible vlaues: :class:`VerticalAlignment <VerticalAlignment>` """
         self.update()
         return self._vertical_alignment
 
@@ -334,7 +334,7 @@ class Cell(object):
         """
         Set horizondal alignemnt of text in the cell
 
-        :param value: Horizondal alignment value, instance of :class:`cell <HorizontalAlignment>`
+        :param value: Horizondal alignment value, instance of :class:`enum <HorizontalAlignment>`
         :return: :class:`cell <Cell>`
         """
         if self._simplecell:
@@ -346,7 +346,7 @@ class Cell(object):
         """
         Set vertical alignemnt of text in the cell
 
-        :param value: Vertical alignment value, instance of :class:`cell <VerticalAlignment>`
+        :param value: Vertical alignment value, instance of :class:`enum <VerticalAlignment>`
         :return: :class:`cell <Cell>`
         """
         if self._simplecell:
@@ -357,7 +357,8 @@ class Cell(object):
     def set_value(self, value):
         """
         Set value of the cell
-\       :param value: value to be set
+
+        :param value: value to be set
         :return: :class:`cell <Cell>`
         """
         self.value = value

--- a/pygsheets/custom_types.py
+++ b/pygsheets/custom_types.py
@@ -22,7 +22,7 @@ class WorkSheetProperty(Enum):
 class ValueRenderOption(Enum):
     """Determines how values should be rendered in the output.
 
-    `Reference <https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption>`_
+    `ValueRenderOption Docs <https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption>`_
 
     FORMATTED_VALUE: Values will be calculated & formatted in the reply according to the cell's formatting.
     Formatting is based on the spreadsheet's locale, not the requesting user's locale.
@@ -44,7 +44,7 @@ class ValueRenderOption(Enum):
 class DateTimeRenderOption(Enum):
     """Determines how dates should be rendered in the output.
 
-    `Reference <https://developers.google.com/sheets/api/reference/rest/v4/DateTimeRenderOption>`_
+    `DateTimeRenderOption Doc <https://developers.google.com/sheets/api/reference/rest/v4/DateTimeRenderOption>`_
 
     SERIAL_NUMBER: Instructs date, time, datetime, and duration fields to be output as doubles in "serial number"
     format, as popularized by Lotus 1-2-3. The whole number portion of the value (left of the
@@ -86,7 +86,8 @@ class ExportType(Enum):
 class HorizontalAlignment(Enum):
     """Horizontal alignment of the cell.
 
-    Reference: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets#horizontalalign
+    `HorizontalAlignment doc <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets#horizontalalign>`_
+
     """
     LEFT = 'LEFT'
     RIGHT = 'RIGHT'
@@ -97,7 +98,8 @@ class HorizontalAlignment(Enum):
 class VerticalAlignment(Enum):
     """Vertical alignment of the cell.
 
-    Reference: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets#verticalalign
+    `VerticalAlignment doc <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets#verticalalign>`_
+
     """
     TOP = 'TOP'
     MIDDLE = 'MIDDLE'

--- a/pygsheets/custom_types.py
+++ b/pygsheets/custom_types.py
@@ -24,15 +24,17 @@ class ValueRenderOption(Enum):
 
     `Reference <https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption>`_
 
-    FORMATTED_VALUE 	Values will be calculated & formatted in the reply according to the cell's formatting.
-                        Formatting is based on the spreadsheet's locale, not the requesting user's locale.
-                        For example, if A1 is 1.23 and A2 is =A1 and formatted as currency,
-                        then A2 would return "$1.23".
-    UNFORMATTED_VALUE 	Values will be calculated, but not formatted in the reply.
-                        For example, if A1 is 1.23 and A2 is =A1 and formatted as currency,
-                        then A2 would return the number 1.23.
-    FORMULA 	        Values will not be calculated. The reply will include the formulas.
-                        For example, if A1 is 1.23 and A2 is =A1 and formatted as currency, then A2 would return "=A1".
+    FORMATTED_VALUE: Values will be calculated & formatted in the reply according to the cell's formatting.
+    Formatting is based on the spreadsheet's locale, not the requesting user's locale.
+    For example, if A1 is 1.23 and A2 is =A1 and formatted as currency,
+    then A2 would return "$1.23".
+
+    UNFORMATTED_VALUE : Values will be calculated, but not formatted in the reply.
+    For example, if A1 is 1.23 and A2 is =A1 and formatted as currency,
+    then A2 would return the number 1.23.
+
+    FORMULA : Values will not be calculated. The reply will include the formulas.
+    For example, if A1 is 1.23 and A2 is =A1 and formatted as currency, then A2 would return "=A1".
     """
     FORMATTED_VALUE = 'FORMATTED_VALUE'
     UNFORMATTED_VALUE = 'UNFORMATTED_VALUE'
@@ -44,14 +46,15 @@ class DateTimeRenderOption(Enum):
 
     `Reference <https://developers.google.com/sheets/api/reference/rest/v4/DateTimeRenderOption>`_
 
-    SERIAL_NUMBER: 	    Instructs date, time, datetime, and duration fields to be output as doubles in "serial number"
-                        format, as popularized by Lotus 1-2-3. The whole number portion of the value (left of the
-                        decimal) counts the days since December 30th 1899. The fractional portion (right of the decimal)
-                        counts the time as a fraction of the day. For example, January 1st 1900 at noon would be 2.5, 2
-                        because it's 2 days after December 30st 1899, and .5 because noon is half a day. February 1st
-                        1900 at 3pm would be 33.625. This correctly treats the year 1900 as not a leap year.
-    FORMATTED_STRING 	Instructs date, time, datetime, and duration fields to be output as strings in their given
-                        number format (which is dependent on the spreadsheet locale).
+    SERIAL_NUMBER: Instructs date, time, datetime, and duration fields to be output as doubles in "serial number"
+    format, as popularized by Lotus 1-2-3. The whole number portion of the value (left of the
+    decimal) counts the days since December 30th 1899. The fractional portion (right of the decimal)
+    counts the time as a fraction of the day. For example, January 1st 1900 at noon would be 2.5, 2
+    because it's 2 days after December 30st 1899, and .5 because noon is half a day. February 1st
+    1900 at 3pm would be 33.625. This correctly treats the year 1900 as not a leap year.
+
+    FORMATTED_STRING: Instructs date, time, datetime, and duration fields to be output as strings in their given
+    number format (which is dependent on the spreadsheet locale).
     """
     SERIAL_NUMBER = 'SERIAL_NUMBER'
     FORMATTED_STRING = 'FORMATTED_STRING'

--- a/pygsheets/datarange.py
+++ b/pygsheets/datarange.py
@@ -38,16 +38,10 @@ class DataRange(object):
     <Datarange my_named_range Sheet1!A1:B2>
     >>> drange.protected = True # make the range protected
     <Datarange my_named_range Sheet1!A1:B2 protected>
-    >>> drange.start = 'B' # make the range unbounded on rows
+    >>> drange.start_addr = 'B' # make the range unbounded on rows
     <Datarange my_named_range Sheet1!A:B protected>
-    >>> drange.indexes = 'B' # make the range unbounded on rows
-    <Datarange my_named_range Sheet1!A:B protected>
-    >>> drange.indexes = 'B' # make the range unbounded on rows
-    <Datarange my_named_range Sheet1!A:B protected>
-
-
-
-
+    >>> drange.end_addr = None # make the range unbounded on both axes
+    <Datarange my_named_range Sheet1 protected>
 
     """
 

--- a/pygsheets/datarange.py
+++ b/pygsheets/datarange.py
@@ -175,7 +175,7 @@ class DataRange(object):
     @property
     def start_addr(self):
         """top-left address of the range"""
-        return self.grid_range.start.tuple
+        return self.grid_range.start.index
 
     @start_addr.setter
     def start_addr(self, addr):
@@ -186,7 +186,7 @@ class DataRange(object):
     @property
     def end_addr(self):
         """bottom-right address of the range"""
-        return self.grid_range.end.tuple
+        return self.grid_range.end.index
 
     @end_addr.setter
     def end_addr(self, addr):

--- a/pygsheets/datarange.py
+++ b/pygsheets/datarange.py
@@ -4,11 +4,7 @@
 pygsheets.datarange
 ~~~~~~~~~~~~~~~~~~~
 
-This module contains DataRange class for storing/manipulating a range of data in spreadsheet. This class can
-be used for group operations, e.g. changing format of all cells in a given range. This can also represent named ranges
-protected ranges, banned ranges etc.
-
-All the proteted range properties are stored in protected_properties.
+This module contains DataRange class.
 
 """
 
@@ -20,7 +16,13 @@ from pygsheets.exceptions import InvalidArgumentValue, CellNotFound
 
 class DataRange(object):
     """
-    DataRange specifies a range of cells in the sheet.
+    DataRange specifies a range of cells in the sheet. It can be unbounded on one or more axes.
+    DataRange is for storing/manipulating a range of data in worksheet. This class can be used for
+    group operations, e.g. changing format of all cells in a given range. This can also
+    represent named ranges protected ranges, banned ranges etc.
+
+    All the proteted range properties are stored in protected_properties.
+
 
     :param start: top left cell address. can be unbounded.
     :param end: bottom right cell address
@@ -30,7 +32,22 @@ class DataRange(object):
     :param name_id: id of named range
     :param namedjson: json representing the NamedRange from api
 
-    >>> Datarange(start='A1', end='B2', worksheet=wks)
+    >>> drange = Datarange(start='A1', end='B2', worksheet=wks)
+    <Datarange Sheet1!A1:B2>
+    >>> drange.name = "my_named_range" # make this datarange a named range
+    <Datarange my_named_range Sheet1!A1:B2>
+    >>> drange.protected = True # make the range protected
+    <Datarange my_named_range Sheet1!A1:B2 protected>
+    >>> drange.start = 'B' # make the range unbounded on rows
+    <Datarange my_named_range Sheet1!A:B protected>
+    >>> drange.indexes = 'B' # make the range unbounded on rows
+    <Datarange my_named_range Sheet1!A:B protected>
+    >>> drange.indexes = 'B' # make the range unbounded on rows
+    <Datarange my_named_range Sheet1!A:B protected>
+
+
+
+
 
     """
 
@@ -115,7 +132,8 @@ class DataRange(object):
     def protected(self, value):
         if value:
             if not self.protected:
-                resp = self._worksheet.create_protected_range(grange=self.grid_range, returnas='json')
+                resp = self._worksheet.create_protected_range(grange=self.grid_range, named_range_id=self._name_id,
+                                                              returnas='json')
                 self.protected_properties.set_json(resp)
         else:
             if self.protected:
@@ -169,6 +187,7 @@ class DataRange(object):
     def start_addr(self, addr):
         self.grid_range.start = addr
         self.update_named_range()
+        self.update_protected_range()
 
     @property
     def end_addr(self):
@@ -179,6 +198,7 @@ class DataRange(object):
     def end_addr(self, addr):
         self.grid_range.end = addr
         self.update_named_range()
+        self.update_protected_range()
 
     @property
     def range(self):

--- a/pygsheets/datarange.py
+++ b/pygsheets/datarange.py
@@ -10,7 +10,7 @@ This module contains DataRange class.
 
 import logging
 
-from pygsheets.grid_range import GridRange
+from pygsheets.address import GridRange
 from pygsheets.exceptions import InvalidArgumentValue, CellNotFound
 
 
@@ -250,7 +250,7 @@ class DataRange(object):
         Change format of all cells in the range
 
         :param cell: a model :class: Cell whose format will be applied to all cells
-        :param fields: comma seprated string of fields of cell to apply, refer to `google api docs <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/cells#CellData> `
+        :param fields: comma seprated string of fields of cell to apply, refer to `google api docs <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/cells#CellData>`__
 
         """
         request = {"repeatCell": {

--- a/pygsheets/datarange.py
+++ b/pygsheets/datarange.py
@@ -19,22 +19,29 @@ from pygsheets.exceptions import InvalidArgumentValue, CellNotFound
 
 class DataRange(object):
     """
-    DataRange specifies a range of cells in the sheet
+    DataRange specifies a range of cells in the sheet.
 
-    :param start: top left cell address
+    :param start: top left cell address. can be unbounded.
     :param end: bottom right cell address
     :param worksheet: worksheet where this range belongs
     :param name: name of the named range
     :param data: data of the range in as row major matrix
     :param name_id: id of named range
     :param namedjson: json representing the NamedRange from api
+
+    >>> Datarange(start='A1', end='B2', worksheet=wks)
+
     """
 
-    def __init__(self, start=None, end=None, worksheet=None, name='', data=None, name_id=None, namedjson=None, protectedjson=None):
+    def __init__(self, start=None, end=None, worksheet=None, name='', data=None, name_id=None, namedjson=None,
+                 protectedjson=None, grange=None):
         self._worksheet = worksheet
         self.logger = logging.getLogger(__name__)
         self._protected_properties = ProtectedRangeProperties()
-        self.grid_range = GridRange(worksheet=worksheet, start=start, end=end)
+        if grange:
+            self.grid_range = grange
+        else:
+            self.grid_range = GridRange(worksheet=worksheet, start=start, end=end)
 
         if namedjson:
             self.grid_range.set_json(namedjson['range'])
@@ -160,7 +167,7 @@ class DataRange(object):
     @property
     def range(self):
         """Range in format A1:C5"""
-        return format_addr(self.grid_range.start.label) + ':' + format_addr(self.grid_range.end.label)
+        return self.grid_range.start.label + ':' + self.grid_range.end.label
 
     @property
     def worksheet(self):
@@ -369,7 +376,7 @@ class DataRange(object):
         return self.grid_range.to_json()
 
     def __getitem__(self, item):
-        if len(self._data[0]) == 0:
+        if len(self._data[0]) == 0 and self.grid_range.width > 0:
             self.fetch()
         if type(item) is int:
             try:

--- a/pygsheets/datarange.py
+++ b/pygsheets/datarange.py
@@ -47,6 +47,7 @@ class DataRange(object):
         if namedjson:
             self.grid_range.set_json(namedjson['range'])
             name_id = namedjson['namedRangeId']
+            name = namedjson['name']
         if protectedjson:
             self.grid_range.set_json(protectedjson['range'])
             name_id = protectedjson.get('namedRangeId', '')  # @TODO get the name also

--- a/pygsheets/grid_range.py
+++ b/pygsheets/grid_range.py
@@ -1,11 +1,12 @@
-from pygsheets import utils
-from pygsheets import exceptions
 from pygsheets.exceptions import InvalidArgumentValue, IncorrectCellLabel
 import re
 
 
 class Address(object):
-    """Represents the address of a cell.
+    """
+    Represents the address of a cell. This can also be unbound in an axes. So 'A' is also
+    a valid address but this requires explict setting of param `allow_non_single`.
+
     >>> a = Address('A1')
     >>> a.label
     A1
@@ -16,6 +17,10 @@ class Address(object):
     >>> a = Address((1, 1))
     >>> a.label
     A1
+    >>> a + (0,1)
+    <Address B1>
+    >>> a == (1, 1)
+    True
     """
 
     _MAGIC_NUMBER = 64
@@ -41,10 +46,12 @@ class Address(object):
 
     @property
     def label(self):
+        """ Label of the current address in A1 format."""
         return self._value_as_label()
 
     @property
     def tuple(self):
+        """Current Address in tuple format. Both axes starts at 1."""
         return tuple(self._value)
 
     def _value_as_label(self):
@@ -101,13 +108,13 @@ class Address(object):
         return self._value[item]
 
     def __add__(self, other):
-        if type(other) is tuple:
+        if type(other) is tuple or isinstance(other, Address):
             return Address((self._value[0] + other[0], self._value[1] + other[1]))
         else:
             raise NotImplementedError
 
     def __sub__(self, other):
-        if type(other) is tuple:
+        if type(other) is tuple or isinstance(other, Address):
             return Address((self._value[0] - other[0], self._value[1] - other[1]))
         else:
             raise NotImplementedError
@@ -131,7 +138,7 @@ class GridRange(object):
     Represents a rectangular (can be unbounded) range of adresses on a sheet.
     All indexes are zero-based. Indexes are closed, e.g the start index and the end index is inclusive
     Missing indexes indicate the range is unbounded on that side.
-
+    
     """
 
     def __init__(self, label=None, worksheet=None, start=None, end=None, worksheet_title=None,

--- a/pygsheets/grid_range.py
+++ b/pygsheets/grid_range.py
@@ -161,8 +161,10 @@ class Address(object):
 class GridRange(object):
     """
     Represents a rectangular (can be unbounded) range of adresses on a sheet.
-    All indexes are zero-based. Indexes are closed, e.g the start index and the end index is inclusive
+    All indexes are one-based and are closed, ie the start index and the end index is inclusive
     Missing indexes indicate the range is unbounded on that side.
+
+    A:B, A1:B3, 1:2 are all valid index, but A:1, 2:D are not
 
     grange.start = (1, None) will make the range unbounded on column
     grange.indexes = ((None, None), (None, None)) will make the range completely unbounded, ie. whole sheet

--- a/pygsheets/grid_range.py
+++ b/pygsheets/grid_range.py
@@ -39,6 +39,9 @@ class Address(object):
             assert type(value[1]) is int or value[1] is None, 'address col should be int'
             self._value = value
             self._validate()
+        elif not value and self.allow_non_single:
+            self._value = (None, None)
+            self._validate()
         elif isinstance(value, Address):
             self._value = self._label_to_coordinates(value.label)
         else:
@@ -171,11 +174,11 @@ class GridRange(object):
         self._worksheet_id = worksheet_id
         self._worksheet = worksheet
         self._label = label
-        self._start = Address(start, True) if start else None
-        self._end = Address(end, True) if end else None
+        self._start = Address(start, True)
+        self._end = Address(end, True)
         if namedjson:
             self.set_json(namedjson)
-        if label:
+        elif label:
             self._calculate_addresses()
         else:
             self._apply_index_constraints()
@@ -212,7 +215,7 @@ class GridRange(object):
     def indexes(self, value):
         if type(value) is not tuple:
             raise InvalidArgumentValue("Please provide a tuple")
-        self._start, self._end = value
+        self._start, self._end = Address(value[0], True), Address(value[1], True)
         self._apply_index_constraints()
         self._calculate_label()
 
@@ -314,7 +317,7 @@ class GridRange(object):
         """ update values from label """
         label = self._label
         self.worksheet_title = label.split('!')[0]
-        self._start, self._end = None, None
+        self._start, self._end = Address(None, True), Address(None, True)
         if len(label.split('!')) > 1:
             rem = label.split('!')[1]
             if ":" in rem:
@@ -356,8 +359,8 @@ class GridRange(object):
         end_col_idx = namedjson.get('endColumnIndex', None)
         start_row_idx = start_row_idx + 1 if start_row_idx is not None else start_row_idx
         start_col_idx = start_col_idx + 1 if start_col_idx is not None else start_col_idx
-        self._start = Address((start_row_idx, end_row_idx), True)
-        self._start = Address((start_col_idx, end_col_idx), True)
+        self._start = Address((start_row_idx, start_col_idx), True)
+        self._end = Address((end_row_idx, end_col_idx), True)
         self._calculate_label()
 
     def get_bounded_indexes(self):

--- a/pygsheets/grid_range.py
+++ b/pygsheets/grid_range.py
@@ -4,8 +4,10 @@ import re
 
 class Address(object):
     """
-    Represents the address of a cell. This can also be unbound in an axes. So 'A' is also
-    a valid address but this requires explict setting of param `allow_non_single`.
+    Represents the address of a cell.
+    This can also be unbound in an axes. So 'A' is also a valid address but this
+    requires explict setting of param `allow_non_single`.
+    Integer Indexes start from 1.
 
     >>> a = Address('A1')
     >>> a.label
@@ -32,9 +34,11 @@ class Address(object):
         if isinstance(value, str):
             self._value = self._label_to_coordinates(value)
         elif isinstance(value, tuple):
-            if value[0] < 1 or value[1] < 1:
-                raise InvalidArgumentValue('Address coordinates may not be below zero: ' + repr(value))
+            assert len(value) == 2, 'tuple should be of length 2'
+            assert type(value[0]) is int or value[0] is None, 'address row should be int'
+            assert type(value[1]) is int or value[1] is None, 'address col should be int'
             self._value = value
+            self._validate()
         elif isinstance(value, Address):
             self._value = self._label_to_coordinates(value.label)
         else:
@@ -54,22 +58,30 @@ class Address(object):
         """Current Address in tuple format. Both axes starts at 1."""
         return tuple(self._value)
 
-    def _value_as_label(self):
-        """Transforms tuple coordinates into a label of the form A1."""
-        if not self.allow_non_single and (not self._value[0] or not self._value[1]):
-            raise InvalidArgumentValue('Address only allows single cell address')
+    def _validate(self):
+        if not self.allow_non_single and (self._value[0] is None or self._value[0] is None):
+            raise InvalidArgumentValue("Address cannot be unbounded if allow_non_single is not set.")
 
-        row_label, column_label = '', ''
         if self._value[0]:
             row = int(self._value[0])
             if row < 1:
                 raise InvalidArgumentValue('Address coordinates may not be below zero: ' + repr(self._value))
-            row_label = str(row)
 
         if self._value[1]:
             col = int(self._value[1])
             if col < 1:
                 raise InvalidArgumentValue('Address coordinates may not be below zero: ' + repr(self._value))
+
+    def _value_as_label(self):
+        """Transforms tuple coordinates into a label of the form A1."""
+        self._validate()
+
+        row_label, column_label = '', ''
+        if self._value[0]:
+            row_label = str(self._value[0])
+
+        if self._value[1]:
+            col = int(self._value[1])
             div = col
             column_label = ''
             while div:
@@ -107,6 +119,11 @@ class Address(object):
     def __getitem__(self, item):
         return self._value[item]
 
+    def __setitem__(self, key, value):
+        current_value = list(self._value)
+        current_value[key] = value
+        self._value = tuple(current_value)
+
     def __add__(self, other):
         if type(other) is tuple or isinstance(other, Address):
             return Address((self._value[0] + other[0], self._value[1] + other[1]))
@@ -132,13 +149,20 @@ class Address(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __bool__(self):
+        return not (self._value[0] is None and self._value[1] is None)
+
+    __nonzero__ = __bool__
+
 
 class GridRange(object):
     """
     Represents a rectangular (can be unbounded) range of adresses on a sheet.
     All indexes are zero-based. Indexes are closed, e.g the start index and the end index is inclusive
     Missing indexes indicate the range is unbounded on that side.
-    
+
+    Reference: `GridRange API docs <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/other#GridRange>`__
+
     """
 
     def __init__(self, label=None, worksheet=None, start=None, end=None, worksheet_title=None,
@@ -154,6 +178,7 @@ class GridRange(object):
         if label:
             self._calculate_addresses()
         else:
+            self._apply_index_constraints()
             self._calculate_label()
 
     @property
@@ -164,6 +189,7 @@ class GridRange(object):
     @start.setter
     def start(self, value):
         self._start = Address(value, allow_non_single=True)
+        self._apply_index_constraints()
         self._calculate_label()
 
     @property
@@ -174,6 +200,20 @@ class GridRange(object):
     @end.setter
     def end(self, value):
         self._end = Address(value, allow_non_single=True)
+        self._apply_index_constraints()
+        self._calculate_label()
+
+    @property
+    def indexes(self):
+        """ Indexes of this range as a tuple """
+        return self.start, self.end
+
+    @indexes.setter
+    def indexes(self, value):
+        if type(value) is not tuple:
+            raise InvalidArgumentValue("Please provide a tuple")
+        self._start, self._end = value
+        self._apply_index_constraints()
         self._calculate_label()
 
     @property
@@ -190,6 +230,7 @@ class GridRange(object):
 
     @property
     def worksheet_id(self):
+        """ Id of woksheet this range belongs to """
         if self._worksheet:
             return self._worksheet.id
         return self._worksheet_id
@@ -205,6 +246,7 @@ class GridRange(object):
 
     @property
     def worksheet_title(self):
+        """ Title of woksheet this range belongs to """
         if self._worksheet:
             return self._worksheet.title
         return self._worksheet_title
@@ -224,6 +266,40 @@ class GridRange(object):
         self._worksheet = value
         self._worksheet_id = value.id
         self._worksheet_title = value.title
+        self._calculate_label()
+
+    def _apply_index_constraints(self, based_on='start'):
+        if not self._start and not self._end:
+            return
+
+        if based_on == 'start':
+            if not self._start:
+                if self._end:
+                    self._start = self._end
+            elif self._start[0] is None or self._end[0] is None:
+                self._start[0], self._end[0] = None, None
+            elif self._start[1] is None or self._end[1] is None:
+                self._start[1], self._end[1] = None, None
+        elif based_on == 'end':
+            if not self._end:
+                if self._start:
+                    self._end = self._start
+            elif self._end[0] is None:
+                self._start[0] = None
+            elif self._end[1] is None:
+                self._start[1] = None
+
+        if (self._start[0] and not self._end[0]) or (not self._start[0] and self._end[0]) or \
+           (self._start[1] and not self._end[1]) or (not self._start[1] and self._end[1]):
+            self._start, self._end = (self._start, self._start) if based_on == 'start' else (self._end, self._end)
+            raise InvalidArgumentValue('Invalid start and end set for this range')
+
+        if self._start and self._end:
+            if self._start[0]:
+                assert self._start[0] <= self._end[0]
+            if self._start[1]:
+                assert self._start[1] <= self._end[1]
+
         self._calculate_label()
 
     def _calculate_label(self):
@@ -246,8 +322,10 @@ class GridRange(object):
                 self._end = Address(rem.split(":")[1], allow_non_single=True)
             else:
                 self._start = Address(rem, allow_non_single=True)
+        self._apply_index_constraints()
 
     def to_json(self):
+        """ Get json representation of this grid range. """
         if self.worksheet_id is None:
             raise Exception("worksheet id not set for this range.")
         self._calculate_addresses()
@@ -255,14 +333,21 @@ class GridRange(object):
         if self._start[0]:
             return_dict["startRowIndex"] = self._start[0] - 1
         if self._start[1]:
-            return_dict["endRowIndex"] = self._start[0]
+            return_dict["startColumnIndex"] = self._start[0]
         if self._end[0]:
-            return_dict["startColumnIndex"] = self._end[0] - 1
+            return_dict["endRowIndex"] = self._end[0] - 1
         if self._end[1]:
             return_dict["endColumnIndex"] = self._end[1]
         return return_dict
 
     def set_json(self, namedjson):
+        """
+        Apply a Gridrange json to this named range.
+
+        :param namedjson: json object of the GridRange format
+
+        Reference: `GridRange docs <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/other#GridRange>`__
+        """
         if 'sheetId' in namedjson:
             self.worksheet_id = namedjson['sheetId']
         start_row_idx = namedjson.get('startRowIndex', None)
@@ -275,25 +360,28 @@ class GridRange(object):
         self._start = Address((start_col_idx, end_col_idx), True)
         self._calculate_label()
 
-    def get_indexes_calculated(self):
+    def get_bounded_indexes(self):
+        """ get bounded indexes of this range based on worksheet size, if the indexes are unbounded """
         if not self._worksheet:
-            raise InvalidArgumentValue('worksheet not set for size')
-        start_r, start_c = iter(self.start)
-        end_r, end_c = iter(self.end)
+            raise InvalidArgumentValue('Worksheet not set for calculating size.')
+        start_r, start_c = tuple(iter(self.start)) if self.start else (None, None)
+        end_r, end_c = tuple(iter(self.end)) if self.end else (None, None)
         start_r = start_r if start_r else 0
         start_c = start_c if start_c else 0
         end_r = end_r if end_r else self._worksheet.rows
-        end_c = end_c if end_c else self._worksheet.cols1
+        end_c = end_c if end_c else self._worksheet.cols
         return Address((start_r, start_c)), Address((end_r, end_c))
 
     @property
     def height(self):
-        start, end = self.get_indexes_calculated()
+        """ Height of this gridrange """
+        start, end = self.get_bounded_indexes()
         return end[0] - start[0] + 1
 
     @property
     def width(self):
-        start, end = self.get_indexes_calculated()
+        """ Width of this gridrange """
+        start, end = self.get_bounded_indexes()
         return end[1] - start[1] + 1
 
     def __repr__(self):

--- a/pygsheets/grid_range.py
+++ b/pygsheets/grid_range.py
@@ -1,24 +1,137 @@
 from pygsheets import utils
 from pygsheets import exceptions
+from pygsheets.exceptions import InvalidArgumentValue, IncorrectCellLabel
+import re
+
+
+class Address(object):
+    """Represents the address of a cell.
+    >>> a = Address('A1')
+    >>> a.label
+    A1
+    >>> a[0]
+    1
+    >>> a[1]
+    1
+    >>> a = Address((1, 1))
+    >>> a.label
+    A1
+    """
+
+    _MAGIC_NUMBER = 64
+
+    def __init__(self, value, allow_non_single=False):
+        self._is_single = True
+        self.allow_non_single = allow_non_single
+
+        if isinstance(value, str):
+            self._value = self._label_to_coordinates(value)
+        elif isinstance(value, tuple):
+            if value[0] < 1 or value[1] < 1:
+                raise InvalidArgumentValue('Address coordinates may not be below zero: ' + repr(value))
+            self._value = value
+        elif isinstance(value, Address):
+            self._value = self._label_to_coordinates(value.label)
+        else:
+            raise IncorrectCellLabel('Only labels in A1 notation, coordinates as a tuple or '
+                                     'pygsheets.Address objects are accepted.')
+
+    def is_valid_single(self):
+        pass
+
+    @property
+    def label(self):
+        return self._value_as_label()
+
+    def _value_as_label(self):
+        """Transforms tuple coordinates into a label of the form A1."""
+        if not self.allow_non_single and (not self._value[0] or not self._value[1]):
+            raise InvalidArgumentValue('Address only allows single cell address')
+
+        row_label, column_label = '', ''
+        if self._value[0]:
+            row = int(self._value[0])
+            if row < 1:
+                raise InvalidArgumentValue('Address coordinates may not be below zero: ' + repr(self._value))
+            row_label = str(row)
+
+        if self._value[1]:
+            col = int(self._value[1])
+            if col < 1:
+                raise InvalidArgumentValue('Address coordinates may not be below zero: ' + repr(self._value))
+            div = col
+            column_label = ''
+            while div:
+                (div, mod) = divmod(div, 26)
+                if mod == 0:
+                    mod = 26
+                    div -= 1
+                column_label = chr(mod + self._MAGIC_NUMBER) + column_label
+
+        return '{}{}'.format(column_label, row_label)
+
+    def _label_to_coordinates(self, label):
+        """Transforms a label in A1 notation into numeric coordinates and returns them as tuple."""
+        m = re.match(r'([A-Za-z]*)(\d*)', label)
+        if m:
+            column_label = m.group(1).upper()
+            row, col = m.group(2), 0
+            if column_label:
+                for i, c in enumerate(reversed(column_label)):
+                    col += (ord(c) - self._MAGIC_NUMBER) * (26 ** i)
+                col = int(col)
+            else:
+                col = None
+            row = int(row) if row else None
+        if not m or (not self.allow_non_single and not (row and col)):
+            raise IncorrectCellLabel('Not a valid cell label format: {}.'.format(label))
+        return row, col
+
+    def __repr__(self):
+        return '<%s %s>' % (self.__class__.__name__, str(self.label))
+
+    def __iter__(self):
+        return iter(self._value)
+
+    def __getitem__(self, item):
+        return self._value[item]
+
+    def __eq__(self, other):
+        if isinstance(other, Address):
+            return self.label == other.label
+        elif type(other) is str:
+            return self.label == other
+        elif type(other) is tuple or type(other) is list:
+            return self._value == tuple(other)
+        else:
+            return super(Address, self).__eq__(other)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class GridRange(object):
-    """ A range on a sheet. All indexes are zero-based.
-    Indexes are half open, e.g the start index is inclusive and the end index is exclusive -- [startIndex, endIndex).
-    Missing indexes indicate the range is unbounded on that side. """
+    """
+    Represents a rectangular (can be unbounded) range of adresses on a sheet.
+    All indexes are zero-based. Indexes are closed, e.g the start index and the end index is inclusive
+    Missing indexes indicate the range is unbounded on that side.
 
-    def __init__(self, label=None, worksheet_id=None, start=None, end=None, spreadsheet=None):
-        self._label = label
-        self._worksheet_name = None
+    """
+
+    def __init__(self, label=None, worksheet=None, start=None, end=None, worksheet_title=None,
+                 worksheet_id=None):
+        self._worksheet_title = worksheet_title
         self._worksheet_id = worksheet_id
-        self._start = start
-        self._end = end
-        self.spreadsheet = spreadsheet
+        self._worksheet = worksheet
+
+        self._label = label
+        self._start = Address(start, True)
+        self._end = Address(end, True)
 
         if label:
-            self._update_values()
+            self._calculate_addresses()
         else:
-            self._update_label()
+            self._calculate_label()
 
     @property
     def start(self):
@@ -27,9 +140,8 @@ class GridRange(object):
 
     @start.setter
     def start(self, value):
-        value = utils.format_addr(value, 'label')
-        self._start = value
-        self._update_label()
+        self._start = Address(value, allow_non_single=True)
+        self._calculate_label()
 
     @property
     def end(self):
@@ -38,59 +150,101 @@ class GridRange(object):
 
     @end.setter
     def end(self, value):
-        value = utils.format_addr(value, 'label')
-        self._end = value
-        self._update_label()
+        self._end = Address(value, allow_non_single=True)
+        self._calculate_label()
 
     @property
     def label(self):
-        """ Label in grid range format """
+        """ Label in A1 notation format """
         return self._label
 
     @label.setter
     def label(self, value):
+        if type(value) is not str:
+            raise InvalidArgumentValue('non string value for label')
         self._label = value
-        self._update_values()
+        self._calculate_addresses()
 
     @property
     def worksheet_id(self):
+        if self._worksheet:
+            return self._worksheet.id
         return self._worksheet_id
 
     @worksheet_id.setter
     def worksheet_id(self, value):
+        if self._worksheet:
+            raise InvalidArgumentValue("This range already has a worksheet set, remove it first.")
         self._worksheet_id = value
-        self._update_label()
+
+    @property
+    def worksheet_title(self):
+        if self._worksheet:
+            return self._worksheet.title
+        return self._worksheet_title
+
+    @worksheet_title.setter
+    def worksheet_title(self, value):
+        if self._worksheet:
+            if self._worksheet.title == value:
+                return
+            else:
+                raise InvalidArgumentValue("This range already has a worksheet set, remove it first.")
+        self._worksheet_title = value
+        self._calculate_label()
 
     def set_worksheet(self, value):
         """ set the worksheet of this grid range. """
-        self.spreadsheet = value.spreadsheet
+        self._worksheet = value
         self._worksheet_id = value.id
-        self._update_label()
+        self._worksheet_title = value.title
+        self._calculate_label()
 
-    def _update_label(self):
+    def _calculate_label(self):
         """update label from values """
-        label = self._worksheet_name
+        label = self.worksheet_title
         if self._start and self._end:
-            label += "!" + self._start + ":" + self._end
+            label += "!" + self._start.label + ":" + self._end.label
         self._label = label
 
-    def _update_values(self):
+    def _calculate_addresses(self):
         """ update values from label """
         label = self._label
-        self._worksheet_name = label.split('!')
+        self.worksheet_title = label.split('!')[0]
+        self._start, self._end = None, None
         if len(label.split('!')) > 1:
             rem = label.split('!')[1]
             if ":" in rem:
-                self._start = rem.split(":")[0]
-                self._end = rem.split(":")[1]
+                self._start = Address(rem.split(":")[0], allow_non_single=True)
+                self._end = Address(rem.split(":")[1], allow_non_single=True)
+            else:
+                self._start = Address(rem, allow_non_single=True)
 
     def to_json(self):
-        self._update_values()
-        # TODO fix
-        return {
-            "sheetId": self._worksheet_id,
-            "startRowIndex": self._start[0]-1,
-            "endRowIndex": self._end[0],
-            "startColumnIndex": self._start[1]-1,
-            "endColumnIndex": self._end[1],
-        }
+        if self.worksheet_id is None:
+            raise Exception("worksheet id not set for this range.")
+        self._calculate_addresses()
+        return_dict = {"sheetId": self.worksheet_id}
+        if self._start[0]:
+            return_dict["startRowIndex"] = self._start[0] - 1
+        if self._start[1]:
+            return_dict["endRowIndex"] = self._start[0]
+        if self._end[0]:
+            return_dict["startColumnIndex"] = self._end[0] - 1
+        if self._end[1]:
+            return_dict["endColumnIndex"] = self._end[1]
+        return return_dict
+
+    def __repr__(self):
+        return '<%s %s>' % (self.__class__.__name__, str(self.label))
+
+    def __eq__(self, other):
+        if isinstance(other, GridRange):
+            return self.label == other.label
+        elif type(other) is str:
+            return self.label == other
+        else:
+            return super(GridRange, self).__eq__(other)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/pygsheets/grid_range.py
+++ b/pygsheets/grid_range.py
@@ -401,16 +401,15 @@ class GridRange(object):
         """ Get json representation of this grid range. """
         if self.worksheet_id is None:
             raise Exception("worksheet id not set for this range.")
-        self._calculate_addresses()
         return_dict = {"sheetId": self.worksheet_id}
-        if self._start[0]:
-            return_dict["startRowIndex"] = self._start[0] - 1
-        if self._start[1]:
-            return_dict["startColumnIndex"] = self._start[1] - 1
-        if self._end[0]:
-            return_dict["endRowIndex"] = self._end[0]
-        if self._end[1]:
-            return_dict["endColumnIndex"] = self._end[1]
+        if self.start[0]:
+            return_dict["startRowIndex"] = self.start[0] - 1
+        if self.start[1]:
+            return_dict["startColumnIndex"] = self.start[1] - 1
+        if self.end[0]:
+            return_dict["endRowIndex"] = self.end[0]
+        if self.end[1]:
+            return_dict["endColumnIndex"] = self.end[1]
         return return_dict
 
     def set_json(self, namedjson):

--- a/pygsheets/grid_range.py
+++ b/pygsheets/grid_range.py
@@ -48,9 +48,6 @@ class Address(object):
             raise IncorrectCellLabel('Only labels in A1 notation, coordinates as a tuple or '
                                      'pygsheets.Address objects are accepted.')
 
-    def is_valid_single(self):
-        pass
-
     @property
     def label(self):
         """ Label of the current address in A1 format."""
@@ -207,7 +204,7 @@ class GridRange(object):
     """
 
     def __init__(self, label=None, worksheet=None, start=None, end=None, worksheet_title=None,
-                 worksheet_id=None, propertiesjson=None, fill_bounds=False):
+                 worksheet_id=None, propertiesjson=None):
         """
         :param label: label in A1 format
         :param worksheet: worksheet object this grange belongs to
@@ -220,7 +217,6 @@ class GridRange(object):
         self._worksheet_title = worksheet_title
         self._worksheet_id = worksheet_id
         self._worksheet = worksheet
-        self._label = label
         self._start = Address(start, True)
         self._end = Address(end, True)
         # if fill_bounds and self._start and not self._end:
@@ -232,7 +228,7 @@ class GridRange(object):
         if propertiesjson:
             self.set_json(propertiesjson)
         elif label:
-            self._calculate_addresses()
+            self._calculate_addresses(label)
         else:
             self._apply_index_constraints()
             self._calculate_label()
@@ -293,15 +289,13 @@ class GridRange(object):
     @property
     def label(self):
         """ Label in A1 notation format """
-        self._calculate_label()
-        return self._label
+        return self._calculate_label()
 
     @label.setter
     def label(self, value):
         if type(value) is not str:
             raise InvalidArgumentValue('non string value for label')
-        self._label = value
-        self._calculate_addresses()
+        self._calculate_addresses(value)
 
     @property
     def worksheet_id(self):
@@ -393,11 +387,10 @@ class GridRange(object):
         label = '' if label is None else label
         if self.start and self.end:
             label += "!" + self.start.label + ":" + self.end.label
-        self._label = label
+        return label
 
-    def _calculate_addresses(self):
+    def _calculate_addresses(self, label):
         """ update values from label """
-        label = self._label
         self.worksheet_title = label.split('!')[0]
         self._start, self._end = Address(None, True), Address(None, True)
         if len(label.split('!')) > 1:

--- a/pygsheets/grid_range.py
+++ b/pygsheets/grid_range.py
@@ -33,11 +33,11 @@ class Address(object):
 
         if isinstance(value, str):
             self._value = self._label_to_coordinates(value)
-        elif isinstance(value, tuple):
+        elif isinstance(value, tuple) or isinstance(value, list):
             assert len(value) == 2, 'tuple should be of length 2'
             assert type(value[0]) is int or value[0] is None, 'address row should be int'
             assert type(value[1]) is int or value[1] is None, 'address col should be int'
-            self._value = value
+            self._value = tuple(value)
             self._validate()
         elif not value and self.allow_non_single:
             self._value = (None, None)
@@ -57,7 +57,17 @@ class Address(object):
         return self._value_as_label()
 
     @property
-    def tuple(self):
+    def row(self):
+        """Row of the address"""
+        return self._value[0]
+
+    @property
+    def col(self):
+        """Column of the address"""
+        return self._value[1]
+
+    @property
+    def index(self):
         """Current Address in tuple format. Both axes starts at 1."""
         return tuple(self._value)
 

--- a/pygsheets/utils.py
+++ b/pygsheets/utils.py
@@ -173,7 +173,7 @@ def allow_gridrange(method):
     def wrapper(self, *args, **kwargs):
         if 'grange' in kwargs:
             grid_range = kwargs.pop('grange')
-            kwargs['start'] = grid_range.tuple
-            kwargs['end'] = grid_range.tuple
+            kwargs['start'] = grid_range.start
+            kwargs['end'] = grid_range.start
         return method(self, *args, **kwargs)
     return wrapper

--- a/pygsheets/utils.py
+++ b/pygsheets/utils.py
@@ -173,7 +173,6 @@ def allow_gridrange(method):
     def wrapper(self, *args, **kwargs):
         if 'grange' in kwargs:
             grid_range = kwargs.pop('grange')
-            kwargs['start'] = grid_range.start
-            kwargs['end'] = grid_range.start
+            kwargs['start'], kwargs['end'] = [x.tuple for x in grid_range.get_bounded_indexes()]
         return method(self, *args, **kwargs)
     return wrapper

--- a/pygsheets/utils.py
+++ b/pygsheets/utils.py
@@ -9,6 +9,7 @@ This module contains utility functions.
 """
 
 from pygsheets.exceptions import (IncorrectCellLabel, InvalidArgumentValue)
+from functools import wraps
 import re
 
 
@@ -160,4 +161,19 @@ def batchable(func):
         else:
             obj._func_calls.append((func, (args, kwargs)))
             return False
+    return wrapper
+
+
+def allow_gridrange(method):
+    """
+    Decorator function casts gridrange in argument to start and end
+    in range method calls.
+    """
+    @wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if 'grange' in kwargs:
+            grid_range = kwargs.pop('grange')
+            kwargs['start'] = grid_range.tuple
+            kwargs['end'] = grid_range.tuple
+        return method(self, *args, **kwargs)
     return wrapper

--- a/pygsheets/utils.py
+++ b/pygsheets/utils.py
@@ -173,6 +173,6 @@ def allow_gridrange(method):
     def wrapper(self, *args, **kwargs):
         if 'grange' in kwargs:
             grid_range = kwargs.pop('grange')
-            kwargs['start'], kwargs['end'] = [x.tuple for x in grid_range.get_bounded_indexes()]
+            kwargs['start'], kwargs['end'] = [x.index for x in grid_range.get_bounded_indexes()]
         return method(self, *args, **kwargs)
     return wrapper

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -15,7 +15,7 @@ import logging
 
 from pygsheets.cell import Cell
 from pygsheets.datarange import DataRange
-from pygsheets.grid_range import GridRange
+from pygsheets.grid_range import GridRange, Address
 from pygsheets.exceptions import (CellNotFound, InvalidArgumentValue, RangeNotFound)
 from pygsheets.utils import numericise_all, format_addr, fullmatch, batchable, allow_gridrange
 from pygsheets.custom_types import *
@@ -244,7 +244,7 @@ class Worksheet(object):
         """
         Returns cell object at given address.
 
-        :param addr: cell address as either tuple (row, col) or cell label 'A1'
+        :param addr: cell address as either tuple (row, col) or cell label 'A1' or Adress
 
         :returns: an instance of a :class:`Cell`
 
@@ -257,15 +257,9 @@ class Worksheet(object):
 
         """
         if not self._linked: return False
-
+        addr = Address(addr)
         try:
-            if type(addr) is str:
-                val = self.client.get_range(self.spreadsheet.id, self._get_range(addr, addr), 'ROWS')[0][0]
-            elif type(addr) is tuple:
-                label = format_addr(addr, 'label')
-                val = self.client.get_range(self.spreadsheet.id, self._get_range(label, label), 'ROWS')[0][0]
-            else:
-                raise CellNotFound
+            val = self.client.get_range(self.spreadsheet.id, self._get_range(addr, addr), 'ROWS')[0][0]
         except Exception as e:
             if str(e).find('exceeds grid limits') != -1:
                 raise CellNotFound
@@ -383,7 +377,7 @@ class Worksheet(object):
         if values == [['']] or values == []: values = [[]]
 
         # cleanup and re-structure the values
-        start, end = [x.tuple for x in grange.get_bounded_indexes()]
+        start, end = [x.index for x in grange.get_bounded_indexes()]
 
         max_rows = end[0] - start[0] + 1
         max_cols = end[1] - start[1] + 1

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -15,7 +15,7 @@ import logging
 
 from pygsheets.cell import Cell
 from pygsheets.datarange import DataRange
-from pygsheets.grid_range import GridRange, Address
+from pygsheets.address import GridRange, Address
 from pygsheets.exceptions import (CellNotFound, InvalidArgumentValue, RangeNotFound)
 from pygsheets.utils import numericise_all, format_addr, fullmatch, batchable, allow_gridrange
 from pygsheets.custom_types import *
@@ -1162,7 +1162,7 @@ class Worksheet(object):
     def get_named_range(self, name):
         """Get a named range by name.
 
-        Reference: `Named range Api object`_
+        Reference: `Named range Api object <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets#namedrange>`_
 
         :param name:    Name of the named range to be retrieved.
         :returns:   :class:`DataRange`
@@ -1182,7 +1182,7 @@ class Worksheet(object):
     def get_named_ranges(self, name=''):
         """Get named ranges from this worksheet.
 
-        Reference: `Named range Api object`_
+        Reference: `Named range Api object <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets#namedrange>`_
 
         :param name:    Name of the named range to be retrieved, if omitted all ranges are retrieved.
         :return: :class:`DataRange`

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -16,7 +16,7 @@ import logging
 from pygsheets.cell import Cell
 from pygsheets.datarange import DataRange
 from pygsheets.exceptions import (CellNotFound, InvalidArgumentValue, RangeNotFound)
-from pygsheets.utils import numericise_all, format_addr, fullmatch, batchable
+from pygsheets.utils import numericise_all, format_addr, fullmatch, batchable, allow_gridrange
 from pygsheets.custom_types import *
 from pygsheets.chart import Chart
 try:
@@ -304,6 +304,7 @@ class Worksheet(object):
         except KeyError:
             raise CellNotFound
 
+    @allow_gridrange
     def get_values(self, start, end, returnas='matrix', majdim='ROWS', include_tailing_empty=True,
                    include_tailing_empty_rows=False, value_render=ValueRenderOption.FORMATTED_VALUE,
                    date_time_render_option=DateTimeRenderOption.SERIAL_NUMBER, **kwargs):
@@ -848,6 +849,7 @@ class Worksheet(object):
             self.update_row(row+1, values)
 
     @batchable
+    @allow_gridrange
     def clear(self, start='A1', end=None, fields="userEnteredValue"):
         """Clear all values in worksheet. Can be limited to a specific range with start & end.
 
@@ -1135,6 +1137,7 @@ class Worksheet(object):
             return list(filter(lambda x: False if x.value.lower().find(pattern) == -1 else True, found_cells))
 
     @batchable
+    @allow_gridrange
     def create_named_range(self, name, start, end, returnas='range'):
         """Create a new named range in this worksheet.
 
@@ -1224,6 +1227,7 @@ class Worksheet(object):
         self.spreadsheet._named_ranges = [x for x in self.spreadsheet._named_ranges if x["namedRangeId"] != range_id]
 
     @batchable
+    @allow_gridrange
     def create_protected_range(self, start, end, returnas='range'):
         """Create protected range.
 
@@ -1455,6 +1459,7 @@ class Worksheet(object):
         new_spreadsheet = self.client.open_by_key(spreadsheet_id)
         return new_spreadsheet[response['index']]
 
+    @allow_gridrange
     def sort_range(self, start, end, basecolumnindex=0, sortorder="ASCENDING"):
         """Sorts the data in rows based on the given column index.
 

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -15,6 +15,7 @@ import logging
 
 from pygsheets.cell import Cell
 from pygsheets.datarange import DataRange
+from pygsheets.grid_range import GridRange
 from pygsheets.exceptions import (CellNotFound, InvalidArgumentValue, RangeNotFound)
 from pygsheets.utils import numericise_all, format_addr, fullmatch, batchable, allow_gridrange
 from pygsheets.custom_types import *
@@ -1227,22 +1228,25 @@ class Worksheet(object):
         self.spreadsheet._named_ranges = [x for x in self.spreadsheet._named_ranges if x["namedRangeId"] != range_id]
 
     @batchable
-    @allow_gridrange
-    def create_protected_range(self, start, end, returnas='range'):
+    def create_protected_range(self, start=None, end=None, grange=None, returnas='range'):
         """Create protected range.
 
         Reference: `Protected range Api object <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets#protectedrange>`_
 
         :param start: adress of the topleft cell
         :param end: adress of the bottomright cell
+        :param grage: grid range to protect, object of :class:`GridRange`
         :param returnas: 'json' or 'range'
 
         """
         if not self._linked: return False
 
+        if not grange:
+            grange = GridRange(worksheet=self, start=start, end=end)
+
         request = {"addProtectedRange": {
             "protectedRange": {
-                "range": self.get_gridrange(start, end)
+                "range": grange.to_json()
             },
         }}
         drange = self.client.sheet.batch_update(self.spreadsheet.id,

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -345,7 +345,7 @@ class Worksheet(object):
         prev_include_tailing_empty_rows, prev_include_tailing_empty = True, True
 
         if not grange:
-            grange = GridRange(worksheet=self, start=start, end=end, fill_bounds=True)
+            grange = GridRange(worksheet=self, start=start, end=end)
         grange.set_worksheet(self)
 
         # fetch the values
@@ -863,7 +863,7 @@ class Worksheet(object):
 
         if not end:
             end = (self.rows, self.cols)
-        grange = GridRange(worksheet=self, start=start, end=end, fill_bounds=True)
+        grange = GridRange(worksheet=self, start=start, end=end)
         request = {"updateCells": {"range": grange.to_json(), "fields": fields}}
         self.client.sheet.batch_update(self.spreadsheet.id, request)
 
@@ -1146,7 +1146,7 @@ class Worksheet(object):
         if not self._linked: return False
 
         if not grange:
-            grange = GridRange(worksheet=self, start=start, end=end, fill_bounds=True)
+            grange = GridRange(worksheet=self, start=start, end=end)
 
         request = {"addNamedRange": {
             "namedRange": {
@@ -1232,7 +1232,7 @@ class Worksheet(object):
         if not self._linked: return False
 
         if not grange:
-            grange = GridRange(worksheet=self, start=start, end=end, fill_bounds=True)
+            grange = GridRange(worksheet=self, start=start, end=end)
 
         request = {"addProtectedRange": {
             "protectedRange": {},

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client
 google-auth-oauthlib
 oauth2client
+google-api-python-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 google-api-python-client
 google-auth-oauthlib
+oauth2client

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
                     read('pygsheets/__init__.py'), re.MULTILINE).group(1)
 
 if sys.version_info[0] < 3:
-    install_require = ['google-api-python-client>=1.5.5', 'google-auth-oauthlib']
+    install_require = ['google-api-python-client>=1.5.5', 'enum34', 'google-auth-oauthlib']
 else:
     install_require = ['google-api-python-client>=1.5.5', 'google-auth-oauthlib', 'oauth2client']
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ if sys.argv[-1] == 'publish':
 def read(filename):
     return open(os.path.join(os.path.dirname(__file__), filename)).read()
 
+
 description = 'Google Spreadsheets Python API v4'
 
 long_description = """
@@ -40,7 +41,7 @@ version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
 if sys.version_info[0] < 3:
     install_require = ['google-api-python-client>=1.5.5', 'enum34', 'google-auth-oauthlib']
 else:
-    install_require = ['google-api-python-client>=1.5.5', 'google-auth-oauthlib']
+    install_require = ['google-api-python-client>=1.5.5', 'google-auth-oauthlib', 'oauth2client']
 
 setup(
     name='pygsheets',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
                     read('pygsheets/__init__.py'), re.MULTILINE).group(1)
 
 if sys.version_info[0] < 3:
-    install_require = ['google-api-python-client>=1.5.5', 'enum34', 'google-auth-oauthlib']
+    install_require = ['google-api-python-client>=1.5.5', 'google-auth-oauthlib']
 else:
     install_require = ['google-api-python-client>=1.5.5', 'google-auth-oauthlib', 'oauth2client']
 


### PR DESCRIPTION
This PR implements a stand alone model for handling cell address. This will unify the label and index conversions. Thanks to @Kordishal for his work on this. This PR also implements a model GridRange, which will be used to represent a range of address(no data). This solves the current hacky solutions of handling unbounded ranges and cross sheet range references, and related issues like #378 . This will also make Datarange mode robust, as it will use Gridrange to handle the address range.

- [ ] Implement Address
- [ ] Implement GridRange
- [ ] Modify DataRange to use GridRange
- [ ] Modify worksheet to use GridRange
- [ ] Modify Cell to use Address
- [ ] Write and modify tests
- [ ] Improve Documentation


Affected Issues: #378 , #276 , #333 