### PR TITLE
removed pd.np dependency and imported np separately

### DIFF
--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -22,8 +22,10 @@ from pygsheets.custom_types import *
 from pygsheets.chart import Chart
 try:
     import pandas as pd
+    import numpy as np
 except ImportError:
     pd = None
+    np = None
 
 
 _warning_mesage = "this {} is deprecated. Use {} instead"
@@ -1300,7 +1302,7 @@ class Worksheet(object):
         nan = kwargs.get('nan', "NaN")
 
         start = format_addr(start, 'tuple')
-        df = df.replace(pd.np.nan, nan)
+        df = df.replace(np.nan, nan)
         values = df.astype('unicode').values.tolist()
         (df_rows, df_cols) = df.shape
         num_indexes = 1


### PR DESCRIPTION
Got this warning while using the 2.0.0 package.
Making necessary changes to avoid the warning.

```
/anaconda3/lib/python3.7/site-packages/pygsheets/worksheet.py:1195: FutureWarning: The pandas.np module is deprecated and will be removed from pandas in a future version. Import numpy directly instead
  df = df.replace(pd.np.nan, nan)
```

Tested that it works as in previous version without the associated warnings.