### PR TITLE
lint: remove unused import

### DIFF
--- a/pygsheets/drive.py
+++ b/pygsheets/drive.py
@@ -1,7 +1,7 @@
 from pygsheets.spreadsheet import Spreadsheet
 from pygsheets.worksheet import Worksheet
 from pygsheets.custom_types import ExportType
-from pygsheets.exceptions import InvalidArgumentValue, CannotRemoveOwnerError, RequestError
+from pygsheets.exceptions import InvalidArgumentValue, CannotRemoveOwnerError
 
 from googleapiclient import discovery
 from googleapiclient.http import MediaIoBaseDownload


### PR DESCRIPTION
I noticed a minor linting issue when searching for `RequestError` in the codebase. 