### PR TITLE
Use environment markers for enum34

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,11 @@ Download
 version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
                     read('pygsheets/__init__.py'), re.MULTILINE).group(1)
 
-if sys.version_info[0] < 3:
-    install_require = ['google-api-python-client>=1.5.5', 'enum34', 'google-auth-oauthlib']
-else:
-    install_require = ['google-api-python-client>=1.5.5', 'google-auth-oauthlib']
+install_require = [
+    'google-api-python-client>=1.5.5',
+    'google-auth-oauthlib',
+    'enum34 >= 1.1.6;python_version<"3.4"',
+]
 
 setup(
     name='pygsheets',


### PR DESCRIPTION
This small MR fixes failing builds for  enum34 library, as for some reason (I am using Poetry inside Docker) for me it was detecting a wrong Python version.. You can see similar examples [here](https://github.com/tensorflow/tensorflow/issues/30200) for example.