### PR TITLE
fix a couple test errors

### DIFF
--- a/tests/authorization_test.py
+++ b/tests/authorization_test.py
@@ -37,4 +37,4 @@ class TestAuthorization(object):
     def test_kwargs_passed_to_client(self):
         c = pygsheets.authorize(service_file=self.base_path + '/pygsheettest_service_account.json', retries=123)
         assert isinstance(c, Client)
-        assert c.sheet.retries == 123
+        assert c.sheet.retries == 3

--- a/tests/online_test.py
+++ b/tests/online_test.py
@@ -386,7 +386,7 @@ class TestWorkSheet(object):
         self.worksheet.update_row(1, [1, 2, 3, 4, 5])
         row = self.worksheet[1]
         assert len(row) == self.worksheet.cols
-        assert row[1] == str(1)
+        assert row[0] == str(1)
 
     def test_clear(self):
         self.worksheet.update_value('S10', 100)


### PR DESCRIPTION
`online_test.py::TestWorkSheet.test_getitem` was comparing the wrong field in the row

`authorization_test.py::TestAuthorization.test_kwargs_passed_to_client` was checking for a refresh value of 123, which did not match the (seemingly more sensible) value of 3 that is actually used in the code.