### PR TITLE
Better creation of file path in export using os.path.join.

### DIFF
--- a/pygsheets/drive.py
+++ b/pygsheets/drive.py
@@ -286,13 +286,14 @@ class DriveAPIWrapper(object):
 
         import io
         file_name = str(sheet.id or tmp) + file_extension if filename is None else filename + file_extension
-        fh = io.FileIO(path + file_name, 'wb')
+        file_path = os.path.join(path, file_name)
+        fh = io.FileIO(file_path, 'wb')
         downloader = MediaIoBaseDownload(fh, request)
         done = False
         while done is False:
             status, done = downloader.next_chunk()
             # logging.info('Download progress: %d%%.', int(status.progress() * 100)) TODO fix this
-        logging.info('Download finished. File saved in %s.', path + file_name)
+        logging.info('Download finished. File saved in %s.', file_path)
 
         if tmp is not None:
             sheet.index = tmp + 1


### PR DESCRIPTION
I faced an issue where after running:
`wks.export(file_format=ExportType.CSV, filename='worksheet', path='/a/b/c')`
I couldn't find the exported file.

The problem was that the path and filename were simply being joined using string concatenation. The usage of `os.path.join` will provide better resilience to imperfect inputs.