### PR TITLE
fix flaky tests/online_test.py::TestCell::test_link

### DIFF
--- a/tests/online_test.py
+++ b/tests/online_test.py
@@ -774,6 +774,10 @@ class TestCell(object):
         assert self.cell.col == 2
         assert self.cell.value == 'new_val'
         assert self.cell.label == 'B2'
+        
+        self.worksheet.clear(start='B2', end='B2')
+        self.cell.row -= 1
+        self.cell.col -= 1
 
     def test_formula(self):
         self.worksheet.update_value('B1', 3)


### PR DESCRIPTION
This PR aims to fix the flaky test `tests/online_test.py::TestCell::test_link`. In previous versions, the test will run into failure when running for multiple times. And the reason is that the parameters `self.cell.row, self.cell.col` didn't get reset. The test failure can be reproduced by 
`pip install pytest-flakefinder`
`pytest --flake-finder --flake-runs=2 tests/online_test.py::TestCell`
Notice that the PR is modifying the test to make it more robust without changing the source code.