### PR TITLE
fix flaky tests/online_test.py::TestCell::test_wrap_strategy

### DIFF
--- a/tests/online_test.py
+++ b/tests/online_test.py
@@ -814,6 +814,8 @@ class TestCell(object):
         cell.wrap_strategy = "WRAP"
         cell = self.worksheet.get_values('A1', 'A1', returnas="range")[0][0]
         assert cell.wrap_strategy == "WRAP"
+        
+        cell.wrap_strategy = None
 
 
 # @pytest.mark.skip()


### PR DESCRIPTION
This PR aims to fix the flaky test `tests/online_test.py::TestCell::test_wrap_strategy`. In previous versions, the test will run into failure when running for multiple times. And the reason is that the parameters `cell.wrap_strategy` didn't get reset in the json file. The test failure can be reproduced by 
`pip install pytest-flakefinder`
`pytest --flake-finder --flake-runs=2 tests/online_test.py::TestCell`
Notice that the PR is modifying the test to make it more robust without changing the source code.