### PR TITLE
Added query paramater to Client.Open

### DIFF
--- a/pygsheets/client.py
+++ b/pygsheets/client.py
@@ -125,7 +125,7 @@ class Client(object):
                                  new_folder=folder)
         return self.spreadsheet_cls(self, jsonsheet=result)
 
-    def open(self, title):
+    def open(self, title, query=None):
         """Open a spreadsheet by title.
 
         In a case where there are several sheets with the same title, the first one found is returned.
@@ -140,7 +140,7 @@ class Client(object):
         :raises pygsheets.SpreadsheetNotFound:  No spreadsheet with the given title was found.
         """
         try:
-            spreadsheet = list(filter(lambda x: x['name'] == title, self.drive.spreadsheet_metadata()))[0]
+            spreadsheet = list(filter(lambda x: x['name'] == title, self.drive.spreadsheet_metadata(query)))[0]
             return self.open_by_key(spreadsheet['id'])
         except (KeyError, IndexError):
             raise SpreadsheetNotFound('Could not find a spreadsheet with title %s.' % title)

--- a/pygsheets/client.py
+++ b/pygsheets/client.py
@@ -135,6 +135,7 @@ class Client(object):
         >>> c.open('TestSheet')
 
         :param title:                           A title of a spreadsheet.
+        :param query:                           Can be used to filter spreadsheet to open i.e query='trashed=false'
 
         :returns:                               :class:`~pygsheets.Spreadsheet`
         :raises pygsheets.SpreadsheetNotFound:  No spreadsheet with the given title was found.


### PR DESCRIPTION
Just minor change to client.open to also have a query parameter, to avoid opening spreadsheet that is trashed.

```
import pygsheets
c = pygsheets.authorize()
c.open('TestSheet', query='trashed=false')
```