### PR TITLE
Fix append table

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -1145,9 +1145,9 @@ class Worksheet(object):
 
         # Prepare the returned data as discussed in issue 546 (https://github.com/nithinmurali/pygsheets/issues/546)
         ret = {
-            'tableRange': GridRange.create(response_json['tableRange'].split("!")[1], self),
+            'tableRange': GridRange.create(response_json['tableRange'].rsplit("!", 1)[1], self),
             'updates': {
-                'updatedRange': GridRange.create(response_json['updates']['updatedRange'].split("!")[1], self),
+                'updatedRange': GridRange.create(response_json['updates']['updatedRange'].rsplit("!", 1)[1], self),
                 'updatedCells': response_json['updates']['updatedCells'],
                 'updatedColumns': response_json['updates']['updatedColumns'],
                 'updatedRows': response_json['updates']['updatedRows'],

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -1145,7 +1145,6 @@ class Worksheet(object):
 
         # Prepare the returned data as discussed in issue 546 (https://github.com/nithinmurali/pygsheets/issues/546)
         ret = {
-            'tableRange': GridRange.create(response_json['tableRange'].rsplit("!", 1)[1], self),
             'updates': {
                 'updatedRange': GridRange.create(response_json['updates']['updatedRange'].rsplit("!", 1)[1], self),
                 'updatedCells': response_json['updates']['updatedCells'],
@@ -1153,6 +1152,12 @@ class Worksheet(object):
                 'updatedRows': response_json['updates']['updatedRows'],
             },
         }
+        # Split this part out, because 'tableRange' seems to only be included in the response_json if the table is not empty.
+        #   ret will include tableRange only if the JSON response includes it.
+        #   See #563 (https://github.com/nithinmurali/pygsheets/issues/563)
+        if 'tableRange' in response_json.keys():
+            ret.update({'tableRange': GridRange.create(response_json['tableRange'].rsplit("!", 1)[1], self)})
+        
         return ret
 
     def replace(self, pattern, replacement=None, **kwargs):

--- a/pygsheets/worksheet.py
+++ b/pygsheets/worksheet.py
@@ -1145,9 +1145,9 @@ class Worksheet(object):
 
         # Prepare the returned data as discussed in issue 546 (https://github.com/nithinmurali/pygsheets/issues/546)
         ret = {
-            'tableRange': GridRange.create(response_json['tableRange'], self),
+            'tableRange': GridRange.create(response_json['tableRange'].split("!")[1], self),
             'updates': {
-                'updatedRange': GridRange.create(response_json['updates']['updatedRange'], self),
+                'updatedRange': GridRange.create(response_json['updates']['updatedRange'].split("!")[1], self),
                 'updatedCells': response_json['updates']['updatedCells'],
                 'updatedColumns': response_json['updates']['updatedColumns'],
                 'updatedRows': response_json['updates']['updatedRows'],


### PR DESCRIPTION
As described in issues #561 and #563, the append_table function has been crashing in version 2.0.6. This is due to a change made for #546, to give the proper return value for this function (version 2.0.5 had no return value for append_table).

Instead of creating a GridRange using the JSON response text directly, e.g. "'Some Sheet'!A1:B4", split it apart and use the cell range only, e.g. "A1:B4". You don't need to add the worksheet name, because it's already being provided in self - and self comes with all sorts of goodies like the worksheet ID built in.

This appears to work correctly - the GridRange(s) created correctly link the worksheet, have the right worksheet ID and link to the overarching spreadsheet, etc. Confirmed it is working in a project, updating the range successfully and not throwing errors.

More testing may be needed in case the JSON response only returns the cell value, but I think Google is pretty good about sending the entire unambiguous range (including the sheet name).