### PR TITLE
Update address.py

### DIFF
--- a/pygsheets/address.py
+++ b/pygsheets/address.py
@@ -446,7 +446,7 @@ class GridRange(object):
         self._start, self._end = Address(None, True), Address(None, True)
 
         if len(label.split('!')) > 1:
-            self.worksheet_title = label.split('!')[0]
+            self.worksheet_title = label.split('!')[0].replace("'","")
             rem = label.split('!')[1]
             if ":" in rem:
                 self._start = Address(rem.split(":")[0], allow_non_single=True)


### PR DESCRIPTION
there is a bug when using append_table(). label API returns title with '' around it so it ends up raising  raise InvalidArgumentValue("This range already has a worksheet with different title set.")

fix is to remove the quotation marks from label.

Thanks