### PR TITLE
fix: google sheet creation when folder id is provided

### DIFF
--- a/pygsheets/client.py
+++ b/pygsheets/client.py
@@ -121,7 +121,7 @@ class Client(object):
         result = self.sheet.create(title, template=template, **kwargs)
         if folder:
             self.drive.move_file(result['spreadsheetId'],
-                                 old_folder=self.drive.spreadsheet_metadata(fid=result['spreadsheetId'])[0].get('parents', [None])[0],
+                                 old_folder=self.drive.spreadsheet_metadata(fid=result['spreadsheetId']).get('parents', [None])[0],
                                  new_folder=folder)
         return self.spreadsheet_cls(self, jsonsheet=result)
 

--- a/tests/online_test.py
+++ b/tests/online_test.py
@@ -107,6 +107,32 @@ class TestClient(object):
         assert title == result.title
         result.delete()
 
+    def test_create_in_folder_by_id(self):
+        result = None
+        folder_id = None
+        exception = None
+
+        # We catch any exceptions here to make sure we clean up the folder and sheet that are created during testing
+        try:
+            folder_title = 'test_create_file_in_folder_folder' + PYTHON_VERSION
+            sheet_title = 'test_create_file_in_folder_folder' + PYTHON_VERSION
+            folder_id = pygsheet_client.drive.create_folder(folder_title)
+            result = pygsheet_client.create(sheet_title, folder=folder_id)
+
+            assert isinstance(result, pygsheets.Spreadsheet)
+            assert sheet_title == result.title
+        except Exception as e:
+            exception = e
+
+        # Clean up sheet and folder
+        if folder_id:
+            pygsheet_client.drive.delete(folder_id)
+        if result:
+            result.delete()
+
+        if exception:
+            pytest.fail(str(exception))
+
 
 # @pytest.mark.skip()
 class TestSpreadSheet(object):

--- a/tests/online_test.py
+++ b/tests/online_test.py
@@ -115,7 +115,7 @@ class TestClient(object):
         # We catch any exceptions here to make sure we clean up the folder and sheet that are created during testing
         try:
             folder_title = 'test_create_file_in_folder_folder' + PYTHON_VERSION
-            sheet_title = 'test_create_file_in_folder_folder' + PYTHON_VERSION
+            sheet_title = 'test_create_file_in_folder_sheet' + PYTHON_VERSION
             folder_id = pygsheet_client.drive.create_folder(folder_title)
             result = pygsheet_client.create(sheet_title, folder=folder_id)
 


### PR DESCRIPTION
Fixes https://github.com/nithinmurali/pygsheets/issues/562 for my usage. I'm not sure if there are more use cases that need to be covered here or other places where the same `self.drive.spreadsheet_metadata(fid=result['spreadsheetId'])` call is made that need to be modified.

Please let me know if you want me to look for more places where this might be an issue or add a test for this particular breakage. I can look into it.