### PR TITLE
[FIX] run_batch with requests from multiple spreadsheets

### DIFF
--- a/pygsheets/sheet.py
+++ b/pygsheets/sheet.py
@@ -51,12 +51,34 @@ class SheetAPIWrapper(object):
         self.batch_mode = mode
         self.batched_requests = dict()
 
-    def run_batch(self):
-        for ss, req in self.batched_requests.items():
+    def run_batch(self, verbose=False, _return_list_if_single=False):
+        """Run all batched_requests, then set self.batched_requests = dict().
+        Runs requests "one spreadsheet at a time".
+        Total number of calls to API service equals number of different spreadsheets.
+
+        :param verbose:                 whether to print 
+        :param _return_list_if_single:  whether to return list if only one spreadsheet in batched_requests
+        
+        returns a list of dicts {spreadsheetId: ..., replies: [...]},
+            with one dict for each spreadsheet.
+
+        _return_list_if_single: bool, default False
+            returns
+        """
+        result = []
+        items = self.batched_requests.items()
+        for i, (ss, req) in enumerate(items):
+            if verbose: print('updating sheet {i} of {L}'.format(i=i+1, L=len(items)), end='\r')
             body = {'requests': req}
             request = self.service.spreadsheets().batchUpdate(spreadsheetId=ss, body=body)
-            return self._execute_requests(request)
+            reply = self._execute_requests(request)
+            result.append(reply)
+        if verbose: print('completed!' + ' '*30, end='\r')
         self.batched_requests = dict()
+        if _return_list_if_single and len(result)==1:
+            return result[0]
+        else:
+            return result
 
     def batch_update(self, spreadsheet_id, requests, **kwargs):
         """

--- a/pygsheets/sheet.py
+++ b/pygsheets/sheet.py
@@ -51,18 +51,18 @@ class SheetAPIWrapper(object):
         self.batch_mode = mode
         self.batched_requests = dict()
 
-    def run_batch(self, verbose=False, _return_list_if_single=False):
+    def run_batch(self, verbose=False, return_list_if_single=False):
         """Run all batched_requests, then set self.batched_requests = dict().
         Runs requests "one spreadsheet at a time".
         Total number of calls to API service equals number of different spreadsheets.
 
         :param verbose:                 whether to print 
-        :param _return_list_if_single:  whether to return list if only one spreadsheet in batched_requests
+        :param return_list_if_single:   whether to return list if only one spreadsheet in batched_requests
         
         returns a list of dicts {spreadsheetId: ..., replies: [...]},
             with one dict for each spreadsheet.
 
-        _return_list_if_single: bool, default False
+        return_list_if_single: bool, default False
             returns
         """
         result = []
@@ -75,7 +75,7 @@ class SheetAPIWrapper(object):
             result.append(reply)
         if verbose: print('completed!' + ' '*30, end='\r')
         self.batched_requests = dict()
-        if _return_list_if_single and len(result)==1:
+        if return_list_if_single and len(result)==1:
             return result[0]
         else:
             return result


### PR DESCRIPTION
Previously, run_batch behavior was not correct (or at least, not intuitive - there was a `return` statement direcly inside a `for` loop).
Previous behavior:
1. batch update all requests for the _first_ spreadsheet in `batched_requests`
2. return reply from that update, without clearing `self.batched_requests`

New behavior:
1. batch update all requests for _each_ spreadsheet in `batched_requests` (one spreadsheet at a time)
2. set `self.batched_requests = dict()`
3. return `result` = list of replies, with length equal to number of spreadsheets. For backwards compatibility, when there is only one spreadsheet the default behavior is to return `result[0]` instead.