### PR TITLE
Updated link in Readme #596

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Batching also happens when you unlink worksheet. But in that case the requests a
 
 This library is still in development phase.
  
-* Follow the [Contributing to Open Source](https://guides.github.com/activities/contributing-to-open-source/) Guide.
+* Follow the [Contributing to Open Source](https://opensource.guide/) Guide.
 * Branch off of the `staging` branch, and submit Pull Requests back to
   that branch.  Note that the `master` branch is used for version
   bumps and hotfixes only.


### PR DESCRIPTION
closes #596 
changes the link for cotributer guide from "https://guides.github.com/activities/contributin-to-open-source/" in line 409, which doesn't exist anymore (and redirects to "https://docs.github.com" the normal docs of github), to "https://opensource.guide/".  which is the new ofical guide of Github about open source contributing.
