### PR TITLE
Remove custom NullHandler

### DIFF
--- a/pygsheets/__init__.py
+++ b/pygsheets/__init__.py
@@ -31,11 +31,5 @@ from pygsheets.exceptions import (PyGsheetsException, AuthenticationError,
 
 # Set default logging handler to avoid "No handler found" warnings.
 import logging
-try:  # Python 2.7+
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
 
-logging.getLogger(__name__).addHandler(NullHandler())
+logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
Since we don't support Python versions earlier than 2.7, we don't need a custom `NullHandler`, `logging` module already has it.