### PR TITLE
Fix issue #605: Use Credentials.tojson() to serialize credentials

### DIFF
--- a/pygsheets/authorization.py
+++ b/pygsheets/authorization.py
@@ -63,17 +63,9 @@ def _get_user_authentication_credentials(client_secret_file, scopes, credential_
         credentials = _get_initial_user_authentication_credentials(client_secret_file, local, scopes)
 
     # Save the credentials for the next run
-    credentials_as_dict = {
-        'token': credentials.token,
-        'refresh_token': credentials.refresh_token,
-        'id_token': credentials.id_token,
-        'token_uri': credentials.token_uri,
-        'client_id': credentials.client_id,
-        'client_secret': credentials.client_secret
-    }
     try:
-        with open(credentials_path, 'w') as file:
-            file.write(json.dumps(credentials_as_dict))
+        with open(credentials_path, mode='w') as file:
+            file.write(credentials.to_json())
     except OSError:
         print("Unable to save the credentials to file-system")
 


### PR DESCRIPTION
Fixes issue #605 

Use [google.oauth2.credentials.Credentials.to_json()](https://google-auth.readthedocs.io/en/stable/reference/google.oauth2.credentials.html#google.oauth2.credentials.Credentials.to_json) instead to save the credentials.  The dictionary format in `credentials_as_dict` is no longer valid and causes subsequent runs to crash when requesting an OAuth refresh grant.

See also Google Sheets guide [here](https://developers.google.com/workspace/sheets/api/quickstart/python#configure_the_sample).